### PR TITLE
Feat: CHAT-223-채팅-조회-API

### DIFF
--- a/src/main/java/com/kuit/chatdiary/controller/ChatController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/ChatController.java
@@ -1,0 +1,30 @@
+package com.kuit.chatdiary.controller;
+
+import com.kuit.chatdiary.dto.chat.ChatGetResponseDTO;
+import com.kuit.chatdiary.service.ChatService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/chat")
+public class ChatController {
+
+    @Autowired
+    private ChatService chatService;
+
+    @GetMapping("/get")
+    public ResponseEntity<List<ChatGetResponseDTO>> getChats(@RequestParam Long chatId) {
+        List<ChatGetResponseDTO> chats = chatService.getChats(chatId);
+        if (chats == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Collections.emptyList());
+        }
+        return ResponseEntity.ok(chatService.getChats(chatId));
+    }
+}

--- a/src/main/java/com/kuit/chatdiary/dto/chat/ChatGetResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/chat/ChatGetResponseDTO.java
@@ -1,0 +1,26 @@
+package com.kuit.chatdiary.dto.chat;
+
+import com.kuit.chatdiary.domain.Chat;
+import com.kuit.chatdiary.domain.ChatType;
+import com.kuit.chatdiary.domain.Sender;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ChatGetResponseDTO {
+
+    private Long chatId;
+    private LocalDateTime createAt;
+    private String content;
+    private ChatType chatType;
+    private Sender sender;
+
+    public ChatGetResponseDTO(Chat chat) {
+        this.chatId = chat.getChatId();
+        this.createAt = chat.getCreateAt();
+        this.content = chat.getContent();
+        this.chatType = chat.getChatType();
+        this.sender = chat.getSender();
+    }
+}

--- a/src/main/java/com/kuit/chatdiary/repository/ChatRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/ChatRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 public interface ChatRepository extends JpaRepository<Chat, Long> {
 
     List<Chat> findTop10ByMember_UserIdOrderByChatIdDesc(Long userId);
-    List<Chat> findTop100ByChatIdGreaterThan(Long lastChatId);
+    List<Chat> findTop10ByChatIdGreaterThan(Long lastChatId);
 }

--- a/src/main/java/com/kuit/chatdiary/repository/ChatRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/ChatRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface ChatRepository extends JpaRepository<Chat, Long> {
 
     List<Chat> findTop10ByMember_UserIdOrderByChatIdDesc(Long userId);
+    List<Chat> findTop100ByChatIdGreaterThan(Long lastChatId);
 }

--- a/src/main/java/com/kuit/chatdiary/service/ChatService.java
+++ b/src/main/java/com/kuit/chatdiary/service/ChatService.java
@@ -3,11 +3,15 @@ package com.kuit.chatdiary.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.*;
 import com.kuit.chatdiary.domain.*;
+import com.kuit.chatdiary.dto.chat.ChatGetResponseDTO;
 import com.kuit.chatdiary.repository.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -64,6 +68,16 @@ public class ChatService {
         }
 
         return "";
+    }
+
+    public List<ChatGetResponseDTO> getChats(Long chatId) {
+        List<Chat> chats = chatRepository.findTop100ByChatIdGreaterThan(chatId);
+        if (chats.isEmpty()) {
+            return null;
+        }
+        return chats.stream()
+                .map(ChatGetResponseDTO::new)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/kuit/chatdiary/service/ChatService.java
+++ b/src/main/java/com/kuit/chatdiary/service/ChatService.java
@@ -71,7 +71,7 @@ public class ChatService {
     }
 
     public List<ChatGetResponseDTO> getChats(Long chatId) {
-        List<Chat> chats = chatRepository.findTop100ByChatIdGreaterThan(chatId);
+        List<Chat> chats = chatRepository.findTop10ByChatIdGreaterThan(chatId);
         if (chats.isEmpty()) {
             return null;
         }


### PR DESCRIPTION
## 요약 (Summary)

<!-- 작업한 부분에 대한 간단한 요약을 작성하세요. -->

- [x]  채팅 조회 기능 추가

## 변경 사항 (Changes)

<!-- 기존과 비교했을 때 해당 PR에서 변경된 내용을 작성하세요. -->
<!-- 어떤 부분을 왜 수정했는지 구체적으로 기술하세요. -->

- /chat/get 엔드포인트를 통해 http 연결 진행하도록 구현하였습니다.
- 사용자가 요청한 chatId 이후의 100개의 채팅 내역을 반환합니다.
- 각 예외 상황에 따른 에러코드 반환되도록 예외처리를 하였습니다.
- 응답은 List<`ChatGetResponseDTO`> 타입으로 반환됩니다.

## 리뷰 요구사항

<!-- 해당 PR에서 중점적으로 혹은 꼭 리뷰가 필요한 사항들을 작성하세요. -->
<!-- 체크리스트, 특별한 주의 사항 등 자유 형식으로 기술하세요. -->

- [ ]  채팅 조회 로직이 알맞은 지 확인 부탁드립니다.
- [x]  채팅 내역이 정상적으로 조회되는 지 확인 부탁드립니다.
- [x] ChatGetResponseDTO가 알맞게 구성되었는지 확인 부탁드립니다.
- [x]  리뷰 편의를 위해 조회 시 10개씩 반환중입니다.
리뷰 완료 시 채팅 조회 개수를 10개 -> 100개로 변경 예정입니다.

## 확인 방법 (선택)

<!-- UI 구현 화면의 스크린샷, 기능 작동 스크린샷 등 작업 결과를 한 눈에 볼 수 있는 자료를 첨부하세요. -->

- 로컬에서 작업 시, 채팅 전송 후에 조회해야 확인 가능합니다!

<img width="1582" alt="image" src="https://github.com/Chat-Diary/BE/assets/128016888/c5c864f0-ac75-459a-86ba-c1b451014342">