### PR TITLE
Feat: Chat-221-BE-API-대화상대 통계

### DIFF
--- a/src/main/java/com/kuit/chatdiary/controller/SenderController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/SenderController.java
@@ -1,0 +1,37 @@
+package com.kuit.chatdiary.controller;
+
+import com.kuit.chatdiary.dto.chat.ChatSenderStaticResponseDTO;
+import com.kuit.chatdiary.dto.diary.DateRangeDTO;
+import com.kuit.chatdiary.service.chat.SenderService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/chat")
+public class SenderController {
+
+    private final SenderService senderService;
+
+    public SenderController(SenderService senderService) {
+        this.senderService = senderService;
+    }
+
+    @GetMapping("/sender")
+    public ResponseEntity<List<ChatSenderStaticResponseDTO>> getTagStatistics(
+            @RequestParam("memberId") Long memberId,
+            @RequestParam("type") String type,
+            @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate localDate) {
+        DateRangeDTO dateRange = senderService.staticsType(type,localDate);
+        List<ChatSenderStaticResponseDTO> tagStatistics = senderService.calculateSenderStatistics(memberId, dateRange.getStartDate()
+                ,dateRange.getEndDate());
+        return ResponseEntity.ok(tagStatistics);
+    }
+
+}

--- a/src/main/java/com/kuit/chatdiary/controller/SenderController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/SenderController.java
@@ -22,7 +22,6 @@ public class SenderController {
     public SenderController(SenderService senderService) {
         this.senderService = senderService;
     }
-
     @GetMapping("/sender")
     public ResponseEntity<List<ChatSenderStaticResponseDTO>> getTagStatistics(
             @RequestParam("memberId") Long memberId,

--- a/src/main/java/com/kuit/chatdiary/dto/chat/ChatSenderStaticResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/chat/ChatSenderStaticResponseDTO.java
@@ -1,0 +1,21 @@
+package com.kuit.chatdiary.dto.chat;
+
+import com.kuit.chatdiary.domain.Sender;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.sql.Date;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatSenderStaticResponseDTO {
+    private Sender sender;
+    private Long chatCount;
+    private double percentage;
+    private Date startDate;
+    private Date endDate;
+}

--- a/src/main/java/com/kuit/chatdiary/dto/chat/DateRangeDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/chat/DateRangeDTO.java
@@ -1,4 +1,4 @@
-package com.kuit.chatdiary.dto.diary;
+package com.kuit.chatdiary.dto.chat;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/kuit/chatdiary/dto/diary/DateRangeDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/diary/DateRangeDTO.java
@@ -1,0 +1,16 @@
+package com.kuit.chatdiary.dto.diary;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.sql.Date;
+
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class DateRangeDTO {
+    private final Date startDate;
+    private final Date endDate;
+}

--- a/src/main/java/com/kuit/chatdiary/repository/ChatRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/ChatRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 @Repository
 public class ChatRepository {
+
     private final EntityManager em;
 
     public ChatRepository(EntityManager em) {

--- a/src/main/java/com/kuit/chatdiary/repository/ChatRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/ChatRepository.java
@@ -1,0 +1,31 @@
+package com.kuit.chatdiary.repository;
+
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Date;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public class ChatRepository {
+    private final EntityManager em;
+
+    public ChatRepository(EntityManager em) {
+        this.em = em;
+    }
+
+    public List<Object[]> countChatsBySenderAndDate(Long userId, Date startDate, Date endDate) {
+        String sql = "SELECT c.sender, COUNT(*) " +
+                "FROM chat c " +
+                "WHERE c.user_id = :userId " +
+                "AND c.create_at BETWEEN :startDate AND :endDate " +
+                "GROUP BY c.sender";
+
+        return em.createNativeQuery(sql)
+                .setParameter("userId", userId)
+                .setParameter("startDate", startDate)
+                .setParameter("endDate", endDate)
+                .getResultList();
+    }
+}

--- a/src/main/java/com/kuit/chatdiary/service/chat/SenderService.java
+++ b/src/main/java/com/kuit/chatdiary/service/chat/SenderService.java
@@ -1,0 +1,85 @@
+package com.kuit.chatdiary.service.chat;
+
+import com.kuit.chatdiary.domain.Sender;
+import com.kuit.chatdiary.dto.chat.ChatSenderStaticResponseDTO;
+import com.kuit.chatdiary.dto.diary.DateRangeDTO;
+import com.kuit.chatdiary.repository.ChatRepository;
+import org.springframework.stereotype.Service;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+
+@Service
+public class SenderService {
+
+    public final ChatRepository chatRepository;
+
+    public SenderService(ChatRepository chatRepository) {
+        this.chatRepository = chatRepository;
+    }
+
+    public List<ChatSenderStaticResponseDTO> calculateSenderStatistics(Long memberId, Date startDate, Date endDate) {
+        List<Object[]> chatStatistics = chatRepository.countChatsBySenderAndDate(memberId, startDate, endDate);
+
+        long totalChats = chatStatistics.stream().mapToLong(e -> (Long) e[1]).sum();
+
+        List<ChatSenderStaticResponseDTO> statisticsList = new ArrayList<>();
+        for (Object[] result : chatStatistics) {
+            Sender sender;
+            if (result[0] instanceof String) {
+                sender = Sender.valueOf((String) result[0]);//enum 으로 변환해서 사용
+            } else {
+                continue;
+            }
+            Long count = (Long) result[1];
+            double percentage = calculatePercent(count, totalChats);
+            statisticsList.add(new ChatSenderStaticResponseDTO(sender, count, percentage, startDate, endDate));
+        }
+        return statisticsList;
+    }
+
+    /** 나중에 메서드 합쳐서 리펙토링 필요 */
+    public double calculatePercent(long count,long totalTags){
+        double percentage = (double) count / totalTags * 100;
+        return Math.round(percentage*10)/10.0;
+    }
+
+    /** 나중에 메서드 합쳐서 리펙토링 필요 */
+    public DateRangeDTO staticsType(String type, LocalDate localDate){
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(java.sql.Date.valueOf(localDate));
+        Date startDate, endDate;
+        switch (type) {
+            case "weekly":
+                /** 주간 -> 해당 주의 시작일과 종료일을 계산 */
+                calendar.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY);
+                startDate = new Date(calendar.getTimeInMillis());
+                calendar.add(Calendar.DAY_OF_WEEK, 6);
+                endDate = new Date(calendar.getTimeInMillis());
+                break;
+            case "monthly":
+                /** 월간 -> 해당 월의 시작일과 종료일을 계산 */
+                calendar.set(Calendar.DAY_OF_MONTH, 1);
+                startDate = new Date(calendar.getTimeInMillis());
+                calendar.add(Calendar.MONTH, 1);
+                calendar.add(Calendar.DAY_OF_MONTH, -1);
+                endDate = new Date(calendar.getTimeInMillis());
+                break;
+            case "yearly":
+                /** 연간 -> 해당 연도의 시작일과 종료일을 계산 */
+                calendar.set(Calendar.DAY_OF_YEAR, 1);
+                startDate = new Date(calendar.getTimeInMillis());
+                calendar.add(Calendar.YEAR, 1);
+                calendar.add(Calendar.DAY_OF_YEAR, -1);
+                endDate = new Date(calendar.getTimeInMillis());
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid type: " + type);
+        }
+        return new DateRangeDTO(startDate, endDate);
+    }
+}


### PR DESCRIPTION
## 요약 (Summary)
- [x] 채팅 대상 통계 기능을 위한 JPA 쿼리 구현 및 관련 서비스와 컨트롤러
- [x] 특정 기간 동안의 사용자별 채팅 메시지 수와 비율을 계산하는 기능

## 변경 사항 (Changes)
- ChatRepository : countChatsBySenderAndDate를 통하여 특정 사용자의 채팅 메시지 수를 기간별로 집계하는 기능을 구현
- SenderService : calculateSenderStatistics 메소드를 추가하여 각 Sender 유형별 채팅 메시지의 수와 전체 대비 비율을 계산하는 로직을 구현
- SenderService : staticsType 메소드를 통해 주간, 월간, 연간 통계의 날짜 범위를 계산하는 기능
- SenderController : getTagStatistics 을 통해 클라이언트 요청에 따라 채팅 통계 데이터를 반환하는 API 엔드포인트를 구현
- 예외처리 : 문자열에서 Sender 열거형으로의 변환 로직을 추가하여 데이터 캐스팅 시 발생할 수 있는 ClassCastException을 예뱡

## 리뷰 요구사항
- [ ] DTO에 필요한 정보만 포함되었는지 검토해주세요
- [ ] api 반환이 적절한지 알려주세요
- [x] 코드를 줄일 수 있는 아이디어가 있다면 알려주세요

## 확인 방법 (선택)
<!-- UI 구현 화면의 스크린샷, 기능 작동 스크린샷 등 작업 결과를 한 눈에 볼 수 있는 자료를 첨부하세요. -->
태그 통계랑 거의 유사합니다.
http://localhost:8080/chat/sender?memberId=1&type=monthly&date=2024-01-26
<img width="868" alt="스크린샷 2024-01-27 오후 8 55 47" src="https://github.com/Chat-Diary/BE/assets/137624597/a33497d8-1282-4232-8586-e5a98dc62de5">

비율 카운트 통계 기간 sender등이 반환 되도록 구현했습니다.
