### PR TITLE
Feat: CHAT-238-BE-API-스트릭-일기

### DIFF
--- a/src/main/java/com/kuit/chatdiary/controller/diary/DiaryStreakController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/diary/DiaryStreakController.java
@@ -22,10 +22,8 @@ public class DiaryStreakController {
 
     @GetMapping("/streak")
     public ResponseEntity<DiaryStreakResponseDTO> getStreakDate(
-            @RequestParam("memberId") Long userId,
-            @RequestParam("date") LocalDate today
-    ){
-        DiaryStreakResponseDTO response=diaryStreakService.streakDate(userId,today);
+            @RequestParam("memberId") Long userId){
+        DiaryStreakResponseDTO response=diaryStreakService.streakDate(userId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/kuit/chatdiary/controller/diary/DiaryStreakController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/diary/DiaryStreakController.java
@@ -1,7 +1,31 @@
 package com.kuit.chatdiary.controller.diary;
 
-import org.springframework.stereotype.Controller;
+import com.kuit.chatdiary.dto.diary.DiaryStreakResponseDTO;
+import com.kuit.chatdiary.service.diary.DiaryStreakService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("diary")
 public class DiaryStreakController {
+
+    private final DiaryStreakService diaryStreakService;
+
+    public DiaryStreakController(DiaryStreakService diaryStreakService) {
+        this.diaryStreakService = diaryStreakService;
+    }
+
+    @GetMapping("/streak")
+    public ResponseEntity<DiaryStreakResponseDTO> getStreakDate(
+            @RequestParam("memberId") Long userId,
+            @RequestParam("date") LocalDate today
+    ){
+        DiaryStreakResponseDTO response=diaryStreakService.streakDate(userId,today);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/kuit/chatdiary/controller/diary/DiaryStreakController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/diary/DiaryStreakController.java
@@ -1,0 +1,7 @@
+package com.kuit.chatdiary.controller.diary;
+
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class DiaryStreakController {
+}

--- a/src/main/java/com/kuit/chatdiary/dto/diary/DiaryStreakResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/diary/DiaryStreakResponseDTO.java
@@ -1,6 +1,12 @@
 package com.kuit.chatdiary.dto.diary;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
 public class DiaryStreakResponseDTO {
-    private Long userId;
-    private String diaryStreakDate;
+    private long diaryStreakDate;
 }

--- a/src/main/java/com/kuit/chatdiary/dto/diary/DiaryStreakResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/diary/DiaryStreakResponseDTO.java
@@ -1,0 +1,6 @@
+package com.kuit.chatdiary.dto.diary;
+
+public class DiaryStreakResponseDTO {
+    private Long userId;
+    private String diaryStreakDate;
+}

--- a/src/main/java/com/kuit/chatdiary/repository/diary/DiaryStreakRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/diary/DiaryStreakRepository.java
@@ -34,6 +34,14 @@ public class DiaryStreakRepository {
         long streakCount = 1;
         Date lastDate = diaries.get(0).getDiaryDate();
 
+        /** 구상도 (리펙시 주석 줄일 예정)
+         * 선택정렬 알고리즘 처럼
+         * 위에서 오늘이라는 검증 끝내면 lastDate라는 것은 리스트의 마지막 일기 일자
+         * 반복문에서 0이 아닌 i=1 부터 시작
+         * 즉 오늘 작성한 일기, 오늘 작성한 일기에서 하루 뺀 날짜와 currentDate의 날짜가 같다면 연속 일수 늘림
+         * currentDate 가 이제 lastDate가 되어 하루 전날짜와 그다음 i=2일때 일기의 일자가 같다면 streakCount 늘림
+         * */
+
         for(int i=1; i<diaries.size(); i++){
             Date currentDate = diaries.get(i).getDiaryDate();
             if(lastDate.toLocalDate().minusDays(1).equals(currentDate.toLocalDate())){

--- a/src/main/java/com/kuit/chatdiary/repository/diary/DiaryStreakRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/diary/DiaryStreakRepository.java
@@ -5,6 +5,7 @@ import jakarta.persistence.EntityManager;
 import org.springframework.stereotype.Repository;
 
 import java.sql.Date;
+import java.time.LocalDate;
 import java.util.List;
 
 @Repository
@@ -16,14 +17,17 @@ public class DiaryStreakRepository {
         this.em = em;
     }
 
-    public Long streakDate(long userId){
+    public Long streakDate(long userId, LocalDate today){
         String jpql = "SELECT d FROM diary d WHERE d.member.userId = :userId ORDER BY d.diaryDate DESC";
 
         List<Diary> diaries =em.createQuery(jpql,Diary.class)
                 .setParameter("userId",userId)
                 .getResultList();
 
-        if (diaries.isEmpty()) {
+        /** 오늘 날짜 기준으로 조회하기위한 조건문
+         *  연속 기록있어도 조회기준 날짜 즉 오늘 작성 일기 없다면 연속작성 기록 없는거로
+         * */
+        if (diaries.isEmpty() || !diaries.get(0).getDiaryDate().toLocalDate().equals(today)) {
             return 0L;
         }
 

--- a/src/main/java/com/kuit/chatdiary/repository/diary/DiaryStreakRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/diary/DiaryStreakRepository.java
@@ -1,0 +1,46 @@
+package com.kuit.chatdiary.repository.diary;
+
+import com.kuit.chatdiary.domain.Diary;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Date;
+import java.util.List;
+
+@Repository
+public class DiaryStreakRepository {
+
+    private final EntityManager em;
+
+    public DiaryStreakRepository(EntityManager em) {
+        this.em = em;
+    }
+
+    public Long streakDate(long userId){
+        String jpql = "SELECT d FROM diary d WHERE d.member.userId = :userId ORDER BY d.diaryDate DESC";
+
+        List<Diary> diaries =em.createQuery(jpql,Diary.class)
+                .setParameter("userId",userId)
+                .getResultList();
+
+        if (diaries.isEmpty()) {
+            return 0L;
+        }
+
+        long streakCount = 1;
+        Date lastDate = diaries.get(0).getDiaryDate();
+
+        for(int i=1; i<diaries.size(); i++){
+            Date currentDate = diaries.get(i).getDiaryDate();
+            if(lastDate.toLocalDate().minusDays(1).equals(currentDate.toLocalDate())){
+                streakCount++;
+                lastDate = currentDate;
+            }else{
+                break;
+            }
+        }
+
+        return streakCount;
+    }
+
+}

--- a/src/main/java/com/kuit/chatdiary/service/diary/DiaryStreakService.java
+++ b/src/main/java/com/kuit/chatdiary/service/diary/DiaryStreakService.java
@@ -14,7 +14,8 @@ public class DiaryStreakService {
         this.diaryStreakRepository = diaryStreakRepository;
     }
 
-    public DiaryStreakResponseDTO streakDate(long userId, LocalDate today){
+    public DiaryStreakResponseDTO streakDate(long userId){
+        LocalDate today=LocalDate.now();
         long streakDate=diaryStreakRepository.streakDate(userId,today);
         DiaryStreakResponseDTO response = new DiaryStreakResponseDTO(streakDate);
         return response;

--- a/src/main/java/com/kuit/chatdiary/service/diary/DiaryStreakService.java
+++ b/src/main/java/com/kuit/chatdiary/service/diary/DiaryStreakService.java
@@ -1,4 +1,23 @@
 package com.kuit.chatdiary.service.diary;
 
+import com.kuit.chatdiary.dto.diary.DiaryStreakResponseDTO;
+import com.kuit.chatdiary.repository.diary.DiaryStreakRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
 public class DiaryStreakService {
+    public final DiaryStreakRepository diaryStreakRepository;
+
+    public DiaryStreakService(DiaryStreakRepository diaryStreakRepository) {
+        this.diaryStreakRepository = diaryStreakRepository;
+    }
+
+    public DiaryStreakResponseDTO streakDate(long userId, LocalDate today){
+        long streakDate=diaryStreakRepository.streakDate(userId,today);
+        DiaryStreakResponseDTO response = new DiaryStreakResponseDTO(streakDate);
+        return response;
+    }
+
 }

--- a/src/main/java/com/kuit/chatdiary/service/diary/DiaryStreakService.java
+++ b/src/main/java/com/kuit/chatdiary/service/diary/DiaryStreakService.java
@@ -1,0 +1,4 @@
+package com.kuit.chatdiary.service.diary;
+
+public class DiaryStreakService {
+}


### PR DESCRIPTION
# 요약 (Summary)
- [x] 일기 연속 작성일 수를 추적하는 기능을 하는 API 입니다.
- [x] 네 개의 레이어로 구성하였습니다.
- [x] 각 레이어는 다음과 같은 역할을 수행하도록 구성해보았습니다.
- [x] 파라매터로 날짜를 받지않고, 서버 시간을 받도록 했습니다.
```
DiaryStreakRepository -> 사용자 ID와 현재 날짜를 인자로 받아, 해당 사용자의 연속 일기 작성일 수를 계산합니다. (쿼리문으로는 일기 목록만을 가져와 자바 로직을 통해 연속일 수를 계산하였습니다.)
DiaryStreakService -> DiaryStreakRepository에서 반환된 연속 일수를 DiaryStreakResponseDTO에 설정합니다.(상위 계층에 도메인 계층 노출 차단)
DiaryStreakResponseDTO -> 연속 작성일 수를 저장하여 클라이언트에 전달할 데이터를 정의합니다. (상위 계층에 도메인 계층 노출 차단)
DiaryStreakController -> 쿨라이언트로부터 GET 요청을 받아 사용자 ID와 날짜를 기반으로 연속 작성일 수를 조회하고, 결과를 DiaryStreakResponseDTO형태로 반환합니다.
```

# 변경 사항 (Changes)
- DiaryStreakRepository: JPQL을 사용하여 특정한 사용자의 일기 목록을 가져오고, 조회하는 기준 날짜부터 연속된 작성일(스티릭)을 계산하는 로직을 구현.
- DiaryStreakService:  DiaryStreakRepository의 결과를 받아 DiaryStreakResponseDTO 객체를 생성하고 반환하는 메소드를 추가.
- DiaryStreakResponseDTO :  연속 작성일 수를 저장하는 DTO 클래스로 설계(정의)
- DiaryStreakController: HTTP GET 요청을 통해 사용자의 연속 작성일 수를 조회할 수 있는 API 엔드포인트로 설계하고 구현

# 추가 변경 사항 (Changes)
- DiaryStreakService :  파라매터로 날짜를 받는 기존 로직을 수정-> 서버 시간을 이용하도록
- DiaryStreakController : 서비스 계층 수정에 따른 당연한 수정

# 리뷰 요구사항
- [x]  DiaryStreakRepository의 JPQL 쿼리와 데이터 처리 로직의 정확성과 효율성을 검토해주세요
- [x] DiaryStreakService의 비즈니스 로직의 적절성과 효율성을 검토해주세요
- [x] DiaryStreakController의 API 엔드포인트 구현이 RESTful한지 검토해주세요

# 확인 방법 

#### 요청 예시
```
http://localhost:8080/diary/streak?memberId=1&date=2024-01-31 
```

#### 예시 쿼리문 ( 연속일은 오늘 날짜 기준입니다. 테스트 하시는 날짜를 고려해서 테스트 해주세요)
```
use chatdiary;
INSERT INTO member (email, password, create_at, update_at)
VALUES ("moonadmiin@gmail.com", "123", NOW(), NOW());

INSERT INTO diary (user_id, diary_date, title, content,create_at, update_at)
VALUES (1,"20240129","1title", "1content", NOW(), NOW()),
(1,"20240130","2title", "2content", NOW(), NOW()),
(1,"20240131","2title", "2content", NOW(), NOW()),(1,"20240201","2title", "2content", NOW(), NOW())
,(1,"20240202","2title", "2content", NOW(), NOW()),(1,"20240203","2title", "2content", NOW(), NOW());

```

#### 포스트맨 결과
<img width="824" alt="스크린샷 2024-01-31 오후 9 44 05" src="https://github.com/Chat-Diary/BE/assets/137624597/5a260ae4-cc9d-424e-97e4-2313f2f80968">

