### PR TITLE
Feat: CHAT-237-BE-API-태그풀

### DIFF
--- a/src/main/java/com/kuit/chatdiary/controller/diary/TagPoolController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/diary/TagPoolController.java
@@ -1,0 +1,25 @@
+package com.kuit.chatdiary.controller.diary;
+
+import com.kuit.chatdiary.dto.diary.TagPoolResponseDTO;
+import com.kuit.chatdiary.service.diary.TagPoolService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/diary")
+public class TagPoolController {
+    private final TagPoolService tagPoolService;
+
+    public TagPoolController(TagPoolService tagPoolService) {
+        this.tagPoolService = tagPoolService;
+    }
+
+    @GetMapping("/tags/pool")
+    public ResponseEntity<List<TagPoolResponseDTO>> getTagPool(){
+        return ResponseEntity.ok(tagPoolService.getTagPool());
+    }
+}

--- a/src/main/java/com/kuit/chatdiary/dto/diary/TagPoolResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/diary/TagPoolResponseDTO.java
@@ -1,7 +1,15 @@
 package com.kuit.chatdiary.dto.diary;
 
 import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class TagPoolResponseDTO {
     private Long tagId;
 

--- a/src/main/java/com/kuit/chatdiary/dto/diary/TagPoolResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/diary/TagPoolResponseDTO.java
@@ -1,0 +1,11 @@
+package com.kuit.chatdiary.dto.diary;
+
+import jakarta.persistence.Column;
+
+public class TagPoolResponseDTO {
+    private Long tagId;
+
+    private String category;
+
+    private String tagName;
+}

--- a/src/main/java/com/kuit/chatdiary/repository/diary/TagPoolRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/diary/TagPoolRepository.java
@@ -1,0 +1,22 @@
+package com.kuit.chatdiary.repository.diary;
+
+import com.kuit.chatdiary.domain.Tag;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class TagPoolRepository {
+
+    private final EntityManager em;
+
+    public TagPoolRepository(EntityManager em) {
+        this.em = em;
+    }
+
+    public List<Tag> findAllTags() {
+        String jpql = "SELECT t FROM tag t";
+        return em.createQuery(jpql, Tag.class).getResultList();
+    }
+}

--- a/src/main/java/com/kuit/chatdiary/repository/diary/TagPoolRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/diary/TagPoolRepository.java
@@ -1,10 +1,15 @@
 package com.kuit.chatdiary.repository.diary;
 
+import com.kuit.chatdiary.domain.DiaryPhoto;
+import com.kuit.chatdiary.domain.DiaryTag;
 import com.kuit.chatdiary.domain.Tag;
+import com.kuit.chatdiary.dto.diary.DiaryListResponseDTO;
+import com.kuit.chatdiary.dto.diary.TagPoolResponseDTO;
 import jakarta.persistence.EntityManager;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Repository
 public class TagPoolRepository {
@@ -15,8 +20,13 @@ public class TagPoolRepository {
         this.em = em;
     }
 
-    public List<Tag> findAllTags() {
+    public List<TagPoolResponseDTO> findAllTags() {
         String jpql = "SELECT t FROM tag t";
-        return em.createQuery(jpql, Tag.class).getResultList();
+        List<Tag> tags = em.createQuery(jpql, Tag.class).getResultList();
+        return tags.stream().map(tag -> new TagPoolResponseDTO(
+                tag.getTagId(),
+                tag.getCategory(),
+                tag.getTagName()
+        )).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/kuit/chatdiary/service/diary/TagPoolService.java
+++ b/src/main/java/com/kuit/chatdiary/service/diary/TagPoolService.java
@@ -1,0 +1,23 @@
+package com.kuit.chatdiary.service.diary;
+
+import com.kuit.chatdiary.domain.Tag;
+import com.kuit.chatdiary.dto.diary.TagPoolResponseDTO;
+import com.kuit.chatdiary.repository.diary.TagPoolRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class TagPoolService {
+
+    private final TagPoolRepository tagPoolRepository;
+
+    public TagPoolService(TagPoolRepository tagPoolRepository) {
+        this.tagPoolRepository = tagPoolRepository;
+    }
+
+    public List<TagPoolResponseDTO> getTagPool(){
+        return tagPoolRepository.findAllTags();
+    }
+
+}


### PR DESCRIPTION
# 요약 (Summary)
- [x] 태그 풀 조회 기능을 구현하였습니다.
- [x] TagPoolRepository, TagPoolService, TagPoolResponseDTO, 그리고 TagPoolController 클래스를 개발하였습니다. 단순히 엔티티를 긁어 오는거라 큰 설명이 필요없을 것 같습니다.

# 변경 사항 (Changes)
- TagPoolRepository: 태그 데이터 전체를 조회하는 JPQL 쿼리로 구성 , 결과를 TagPoolResponseDTO로 변환하는 로직을 포함.
- TagPoolService: 리포지토리에서 받은 데이터를 처리하고, 이를 TagPoolResponseDTO 리스트 형태로 반환하는 역할을 합니다. (DTO로 변환처리는 레포지 계층에서 끝냈습니다.)
- TagPoolResponseDTO : 클라이언트에게 전달될 태그 데이터를 정의(카테고리,이름,아이디)
- TagPoolController : HTTP 요청을 처리하고, TagPoolService를 통해 얻은 데이터를 응답으로 반환하는 REST API 엔드포인트를 구현. (단순히 서비스 계층 매소드 호출)

# 리뷰 요구사항
- [x] TagPoolRepository에서는 JPQL 쿼리가 정확한지 검토해 주시기 바랍니다.
- [x] TagPoolService와 TagPoolResponseDTO의 정의들이 적절한지 검토 부탁드립니다.
- [ ] <span style="color:red"> TagPoolController의 REST API 엔드포인트가 데이터들을 잘 반환하는지 확인 부탁드립니다. </span>

# 확인 방법

#### 예시 요청 주소  
```
http://localhost:8080/diary/tags/pool
```

#### 포스트맨 결과
<img width="868" alt="스크린샷 2024-01-31 오후 11 57 47" src="https://github.com/Chat-Diary/BE/assets/137624597/b6d32efe-ff79-4050-8f23-db4cae1205f2">

#### 예시 쿼리문
```
INSERT INTO tag (category, tag_name) 
VALUES ("감정", "기쁨"), ("감정", "슬픔"), ("감정", "화남"), ("감정", "피곤함"), ("감정", "설렘"), ("감정", "당황"), ("감정", "무서움"), 
       ("인물", "친구"), ("인물", "가족"), ("인물", "동료"), ("인물", "애인"), ("인물", "지인"),
       ("행동", "식사"), ("행동", "공부"), ("행동", "여행"), ("행동", "술"), ("행동", "영화"),
       ("행동", "수다"), ("행동", "게임"), ("행동", "업무"), ("행동", "운동"), ("행동", "휴식"), ("행동", "독서"), ("행동", "쇼핑"),
       ("장소", "식당"), ("장소", "학교"), ("장소", "회사"), ("장소", "집"), ("장소", "버스"), ("장소", "카페"), ("장소", "병원"),
       ("장소", "헬스장"), ("장소", "은행"), ("장소", "공항");
```
