### PR TITLE
Feat: CHAT-231-BE-일기상세조회-이미지추가

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "develop" ]
   pull_request:
-    branches: [ "develop" ]
+    branches: [  ]
 
 permissions:
   contents: read

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -61,9 +61,9 @@ jobs:
           --build-arg REGION=${{ secrets.REGION }} \
           --build-arg ACCESS_KEY=${{ secrets.ACCESS_KEY }} \
           --build-arg SECRET_KEY=${{ secrets.SECRET_KEY }} \
-          -t chatdiary/chatdiary-image:latest .
+          -t ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPO_NAME }} .
           docker images
-          docker push chatdiary/chatdiary-image:latest
+          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPO_NAME }}
 
       - name: deploy
         uses: appleboy/ssh-action@master

--- a/src/main/java/com/kuit/chatdiary/controller/DiaryController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/DiaryController.java
@@ -34,7 +34,7 @@ public class DiaryController {
 
 
     @GetMapping("/detail")
-    public ResponseEntity<DiaryShowDetailResponseDTO> showDiary(@RequestParam(name="user_id") Long userId, @RequestParam(name="diary_date") Date diaryDate) throws ParseException, ParseException {
+    public ResponseEntity<DiaryShowDetailResponseDTO> showDiary(@RequestParam(name="user_id") Long userId, @RequestParam(name="diary_date") Date diaryDate) throws Exception {
         log.info("[DiaryController.showDiary]");
 
         return ResponseEntity.ok().body(diaryService.showDiary(userId,diaryDate));

--- a/src/main/java/com/kuit/chatdiary/controller/SenderController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/SenderController.java
@@ -1,0 +1,37 @@
+package com.kuit.chatdiary.controller;
+
+import com.kuit.chatdiary.dto.chat.ChatSenderStaticResponseDTO;
+import com.kuit.chatdiary.dto.diary.DateRangeDTO;
+import com.kuit.chatdiary.service.chat.SenderService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/chat")
+public class SenderController {
+
+    private final SenderService senderService;
+
+    public SenderController(SenderService senderService) {
+        this.senderService = senderService;
+    }
+
+    @GetMapping("/sender")
+    public ResponseEntity<List<ChatSenderStaticResponseDTO>> getTagStatistics(
+            @RequestParam("memberId") Long memberId,
+            @RequestParam("type") String type,
+            @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate localDate) {
+        DateRangeDTO dateRange = senderService.staticsType(type,localDate);
+        List<ChatSenderStaticResponseDTO> tagStatistics = senderService.calculateSenderStatistics(memberId, dateRange.getStartDate()
+                ,dateRange.getEndDate());
+        return ResponseEntity.ok(tagStatistics);
+    }
+
+}

--- a/src/main/java/com/kuit/chatdiary/controller/SenderController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/SenderController.java
@@ -1,17 +1,13 @@
 package com.kuit.chatdiary.controller;
 
-import com.kuit.chatdiary.dto.chat.ChatSenderStaticResponseDTO;
+import com.kuit.chatdiary.dto.chat.ChatSenderStatisticsResponseDTO;
 import com.kuit.chatdiary.dto.diary.DateRangeDTO;
 import com.kuit.chatdiary.service.chat.SenderService;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.time.LocalDate;
-import java.util.List;
 
 @RestController
 @RequestMapping("/chat")
@@ -24,14 +20,12 @@ public class SenderController {
     }
 
     @GetMapping("/sender")
-    public ResponseEntity<List<ChatSenderStaticResponseDTO>> getTagStatistics(
+    public ResponseEntity<ChatSenderStatisticsResponseDTO> getSenderStatistics(
             @RequestParam("memberId") Long memberId,
-            @RequestParam("type") String type,
-            @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate localDate) {
-        DateRangeDTO dateRange = senderService.staticsType(type,localDate);
-        List<ChatSenderStaticResponseDTO> tagStatistics = senderService.calculateSenderStatistics(memberId, dateRange.getStartDate()
-                ,dateRange.getEndDate());
-        return ResponseEntity.ok(tagStatistics);
+            @RequestParam("type") String type) {
+        DateRangeDTO dateRange = senderService.staticsType(type);
+        ChatSenderStatisticsResponseDTO senderStatistics = senderService.calculateSenderStatistics(memberId, dateRange.getStartDate(), dateRange.getEndDate());
+        return ResponseEntity.ok(senderStatistics);
     }
 
 }

--- a/src/main/java/com/kuit/chatdiary/controller/diary/DiaryStreakController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/diary/DiaryStreakController.java
@@ -1,0 +1,29 @@
+package com.kuit.chatdiary.controller.diary;
+
+import com.kuit.chatdiary.dto.diary.DiaryStreakResponseDTO;
+import com.kuit.chatdiary.service.diary.DiaryStreakService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("diary")
+public class DiaryStreakController {
+
+    private final DiaryStreakService diaryStreakService;
+
+    public DiaryStreakController(DiaryStreakService diaryStreakService) {
+        this.diaryStreakService = diaryStreakService;
+    }
+
+    @GetMapping("/streak")
+    public ResponseEntity<DiaryStreakResponseDTO> getStreakDate(
+            @RequestParam("memberId") Long userId){
+        DiaryStreakResponseDTO response=diaryStreakService.streakDate(userId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/kuit/chatdiary/controller/diary/DiaryTagStatisticsController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/diary/DiaryTagStatisticsController.java
@@ -1,14 +1,9 @@
 package com.kuit.chatdiary.controller.diary;
 
-import com.kuit.chatdiary.dto.diary.DateRangeDTO;
-import com.kuit.chatdiary.dto.diary.TagStatisticResponseDTO;
+import com.kuit.chatdiary.dto.diary.TagStatisticsWithDateResponseDTO;
 import com.kuit.chatdiary.service.diary.DiaryTagStatisticsService;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.time.LocalDate;
-import java.util.List;
 
 @RestController
 @RequestMapping("/diary")
@@ -21,13 +16,10 @@ public class DiaryTagStatisticsController {
     }
 
     @GetMapping("/tags")
-    public ResponseEntity<List<TagStatisticResponseDTO>> getTagStatistics(
+    public ResponseEntity<TagStatisticsWithDateResponseDTO> getTagStatistics(
             @RequestParam("memberId") Long memberId,
-            @RequestParam("type") String type,
-            @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate localDate) {
-        DateRangeDTO dateRange = diaryTagStatisticsService.staticsType(type,localDate);
-        List<TagStatisticResponseDTO> tagStatistics = diaryTagStatisticsService.calculateTagStatistics(memberId, dateRange.getStartDate()
-                ,dateRange.getEndDate());
+            @RequestParam("type") String type) {
+        TagStatisticsWithDateResponseDTO tagStatistics = diaryTagStatisticsService.calculateTagStatistics(memberId, type);
         return ResponseEntity.ok(tagStatistics);
     }
 }

--- a/src/main/java/com/kuit/chatdiary/controller/diary/TagPoolController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/diary/TagPoolController.java
@@ -1,0 +1,25 @@
+package com.kuit.chatdiary.controller.diary;
+
+import com.kuit.chatdiary.dto.diary.TagPoolResponseDTO;
+import com.kuit.chatdiary.service.diary.TagPoolService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/diary")
+public class TagPoolController {
+    private final TagPoolService tagPoolService;
+
+    public TagPoolController(TagPoolService tagPoolService) {
+        this.tagPoolService = tagPoolService;
+    }
+
+    @GetMapping("/tags/pool")
+    public ResponseEntity<List<TagPoolResponseDTO>> getTagPool(){
+        return ResponseEntity.ok(tagPoolService.getTagPool());
+    }
+}

--- a/src/main/java/com/kuit/chatdiary/controller/diary/TagSearchController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/diary/TagSearchController.java
@@ -17,7 +17,7 @@ public class TagSearchController {
         this.tagSearchService = tagSearchService;
     }
     @GetMapping("/list/tag")
-    public List<TagSearchResponseDTO> findByTag(@RequestParam(name = "tagName") List<String> tagNames) {
-        return tagSearchService.findByTag(tagNames);
+    public List<TagSearchResponseDTO> findByTag(@RequestParam("userId") Long userId, @RequestParam(name = "tagName") List<String> tagNames) {
+        return tagSearchService.findByTag(tagNames,userId);
     }
 }

--- a/src/main/java/com/kuit/chatdiary/domain/Member.java
+++ b/src/main/java/com/kuit/chatdiary/domain/Member.java
@@ -23,6 +23,7 @@ public class Member {
     @Column(name = "user_id")
     private Long userId;
 
+    @Column(columnDefinition = "TEXT")
     private String email;
 
     private String password;

--- a/src/main/java/com/kuit/chatdiary/domain/Photo.java
+++ b/src/main/java/com/kuit/chatdiary/domain/Photo.java
@@ -19,6 +19,6 @@ public class Photo {
     @JoinColumn(name = "chat_id")
     private Chat chat;
 
-    @Column(name = "image_url")
+    @Column(columnDefinition = "TEXT", name = "image_url")
     private String imageUrl;
 }

--- a/src/main/java/com/kuit/chatdiary/dto/chat/ChatSenderDetailResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/chat/ChatSenderDetailResponseDTO.java
@@ -1,0 +1,17 @@
+package com.kuit.chatdiary.dto.chat;
+
+import com.kuit.chatdiary.domain.Sender;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatSenderDetailResponseDTO {
+    private Sender sender;
+    private Long chatCount;
+    private double percentage;
+}

--- a/src/main/java/com/kuit/chatdiary/dto/chat/ChatSenderStaticResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/chat/ChatSenderStaticResponseDTO.java
@@ -1,0 +1,21 @@
+package com.kuit.chatdiary.dto.chat;
+
+import com.kuit.chatdiary.domain.Sender;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.sql.Date;
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatSenderStaticResponseDTO {
+
+    private Sender sender;
+    private Long chatCount;
+    private double percentage;
+    private Date startDate;
+    private Date endDate;
+}

--- a/src/main/java/com/kuit/chatdiary/dto/chat/ChatSenderStatisticsResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/chat/ChatSenderStatisticsResponseDTO.java
@@ -1,21 +1,19 @@
 package com.kuit.chatdiary.dto.chat;
 
-import com.kuit.chatdiary.domain.Sender;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.sql.Date;
+import java.util.List;
+
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class ChatSenderStaticResponseDTO {
-
-    private Sender sender;
-    private Long chatCount;
-    private double percentage;
+public class ChatSenderStatisticsResponseDTO {
     private Date startDate;
     private Date endDate;
+    private List<ChatSenderDetailResponseDTO> statistics;
 }

--- a/src/main/java/com/kuit/chatdiary/dto/diary/DateRangeDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/diary/DateRangeDTO.java
@@ -6,7 +6,6 @@ import lombok.Setter;
 
 import java.sql.Date;
 
-
 @AllArgsConstructor
 @Getter
 @Setter
@@ -14,3 +13,4 @@ public class DateRangeDTO {
     private final Date startDate;
     private final Date endDate;
 }
+

--- a/src/main/java/com/kuit/chatdiary/dto/diary/DiaryShowDetailResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/diary/DiaryShowDetailResponseDTO.java
@@ -19,12 +19,12 @@ public class DiaryShowDetailResponseDTO {
 
     private String title;
 
-    //private String imgUrl;
     private List<String> imgUrl;
 
     private String content;
 
-    //private String tagName;
     private List<String> tagName;
+
+    private Long CharacterIndex;
 
 }

--- a/src/main/java/com/kuit/chatdiary/dto/diary/DiaryStreakResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/diary/DiaryStreakResponseDTO.java
@@ -1,0 +1,12 @@
+package com.kuit.chatdiary.dto.diary;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class DiaryStreakResponseDTO {
+    private long diaryStreakDate;
+}

--- a/src/main/java/com/kuit/chatdiary/dto/diary/TagPoolResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/diary/TagPoolResponseDTO.java
@@ -1,0 +1,19 @@
+package com.kuit.chatdiary.dto.diary;
+
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TagPoolResponseDTO {
+    private Long tagId;
+
+    private String category;
+
+    private String tagName;
+}

--- a/src/main/java/com/kuit/chatdiary/dto/diary/TagStatisticResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/diary/TagStatisticResponseDTO.java
@@ -16,7 +16,4 @@ public class TagStatisticResponseDTO {
     private String tagName;
     private Long count;
     private double percentage;
-    private Date startDate;
-    private Date endDate;
-
 }

--- a/src/main/java/com/kuit/chatdiary/dto/diary/TagStatisticsWithDateResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/diary/TagStatisticsWithDateResponseDTO.java
@@ -1,0 +1,17 @@
+package com.kuit.chatdiary.dto.diary;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.sql.Date;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class TagStatisticsWithDateResponseDTO {
+    private Date startDate;
+    private Date endDate;
+    private List<TagStatisticResponseDTO> Statistics;
+}

--- a/src/main/java/com/kuit/chatdiary/repository/DiaryRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/DiaryRepository.java
@@ -44,6 +44,7 @@ public class DiaryRepository {
             content = (String) result[2];
         }
 
+
         List<String> imageUrlList =  em.createQuery("SELECT p.imageUrl FROM diaryphoto dp LEFT OUTER JOIN dp.photo p"+
                 " WHERE dp.diary.diaryId = :diary_id").setParameter("diary_id", diaryId).getResultList();
 
@@ -57,10 +58,13 @@ public class DiaryRepository {
                         " GROUP BY c.sender ORDER BY cnt DESC, latest_created_at DESC")
                 .setParameter("diary_date", diaryDate).setParameter("user", Sender.USER).getResultList();
 
+        if(senderCounts.size()==0){
+            return new DiaryShowDetailResponseDTO(diaryDate, title, imageUrlList, content, tagNameList, null);
+        }
+
         Sender sender = (Sender) senderCounts.get(0)[0];
-
-
         return new DiaryShowDetailResponseDTO(diaryDate, title, imageUrlList, content, tagNameList, (long) sender.getIndex());
+
 
     }
 

--- a/src/main/java/com/kuit/chatdiary/repository/diary/DiaryStreakRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/diary/DiaryStreakRepository.java
@@ -1,0 +1,58 @@
+package com.kuit.chatdiary.repository.diary;
+
+import com.kuit.chatdiary.domain.Diary;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public class DiaryStreakRepository {
+
+    private final EntityManager em;
+
+    public DiaryStreakRepository(EntityManager em) {
+        this.em = em;
+    }
+
+    public Long streakDate(long userId, LocalDate today){
+        String jpql = "SELECT d FROM diary d WHERE d.member.userId = :userId ORDER BY d.diaryDate DESC";
+
+        List<Diary> diaries =em.createQuery(jpql,Diary.class)
+                .setParameter("userId",userId)
+                .getResultList();
+
+        /** 오늘 날짜 기준으로 조회하기위한 조건문
+         *  연속 기록있어도 조회기준 날짜 즉 오늘 작성 일기 없다면 연속작성 기록 없는거로
+         * */
+        if (diaries.isEmpty() || !diaries.get(0).getDiaryDate().toLocalDate().equals(today)) {
+            return 0L;
+        }
+
+        long streakCount = 1;
+        Date lastDate = diaries.get(0).getDiaryDate();
+
+        /** 구상도 (리펙시 주석 줄일 예정)
+         * 선택정렬 알고리즘 처럼
+         * 위에서 오늘이라는 검증 끝내면 lastDate라는 것은 리스트의 마지막 일기 일자
+         * 반복문에서 0이 아닌 i=1 부터 시작
+         * 즉 오늘 작성한 일기, 오늘 작성한 일기에서 하루 뺀 날짜와 currentDate의 날짜가 같다면 연속 일수 늘림
+         * currentDate 가 이제 lastDate가 되어 하루 전날짜와 그다음 i=2일때 일기의 일자가 같다면 streakCount 늘림
+         * */
+
+        for(int i=1; i<diaries.size(); i++){
+            Date currentDate = diaries.get(i).getDiaryDate();
+            if(lastDate.toLocalDate().minusDays(1).equals(currentDate.toLocalDate())){
+                streakCount++;
+                lastDate = currentDate;
+            }else{
+                break;
+            }
+        }
+
+        return streakCount;
+    }
+
+}

--- a/src/main/java/com/kuit/chatdiary/repository/diary/TagPoolRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/diary/TagPoolRepository.java
@@ -1,0 +1,32 @@
+package com.kuit.chatdiary.repository.diary;
+
+import com.kuit.chatdiary.domain.DiaryPhoto;
+import com.kuit.chatdiary.domain.DiaryTag;
+import com.kuit.chatdiary.domain.Tag;
+import com.kuit.chatdiary.dto.diary.DiaryListResponseDTO;
+import com.kuit.chatdiary.dto.diary.TagPoolResponseDTO;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Repository
+public class TagPoolRepository {
+
+    private final EntityManager em;
+
+    public TagPoolRepository(EntityManager em) {
+        this.em = em;
+    }
+
+    public List<TagPoolResponseDTO> findAllTags() {
+        String jpql = "SELECT t FROM tag t";
+        List<Tag> tags = em.createQuery(jpql, Tag.class).getResultList();
+        return tags.stream().map(tag -> new TagPoolResponseDTO(
+                tag.getTagId(),
+                tag.getCategory(),
+                tag.getTagName()
+        )).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/kuit/chatdiary/repository/diary/TagSearchRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/diary/TagSearchRepository.java
@@ -18,16 +18,17 @@ public class TagSearchRepository {
 
 
     /** 지식 한계로 쿼리문 세개를 나눠서.. */
-    public List<TagSearchResponseDTO> findByTag(List<String> tagName) {
+    public List<TagSearchResponseDTO> findByTag(List<String> tagName, Long userId) {
         int tagCount = tagName.size();
         List<Diary> diaries = em.createQuery(
                         "SELECT d FROM diary d " +
                                 "JOIN diarytag dt ON d.diaryId = dt.diary.diaryId " +
                                 "JOIN tag t ON dt.tag.tagId = t.tagId " +
-                                "WHERE t.tagName IN :tagNames " +
+                                "WHERE t.tagName IN :tagNames AND d.member.userId = :userId " +
                                 "GROUP BY d " +
                                 "HAVING COUNT(DISTINCT t) = :tagCount", Diary.class)
                 .setParameter("tagNames", tagName)
+                .setParameter("userId", userId)
                 .setParameter("tagCount", (long) tagCount)
                 .getResultList();
 

--- a/src/main/java/com/kuit/chatdiary/repository/statics/SenderRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/statics/SenderRepository.java
@@ -1,0 +1,30 @@
+package com.kuit.chatdiary.repository.statics;
+
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Date;
+import java.util.List;
+
+@Repository
+public class SenderRepository {
+
+    private final EntityManager em;
+    public SenderRepository(EntityManager em) {
+        this.em = em;
+    }
+
+    public List<Object[]> countChatsBySenderAndDate(Long userId, Date startDate, Date endDate) {
+        String sql = "SELECT c.sender, COUNT(*) " +
+                "FROM chat c " +
+                "WHERE c.user_id = :userId " +
+                "AND c.create_at BETWEEN :startDate AND :endDate " +
+                "GROUP BY c.sender";
+
+        return em.createNativeQuery(sql)
+                .setParameter("userId", userId)
+                .setParameter("startDate", startDate)
+                .setParameter("endDate", endDate)
+                .getResultList();
+    }
+}

--- a/src/main/java/com/kuit/chatdiary/service/DiaryService.java
+++ b/src/main/java/com/kuit/chatdiary/service/DiaryService.java
@@ -32,7 +32,7 @@ public class DiaryService {
 
     private final S3Uploader s3Uploader;
 
-    public DiaryShowDetailResponseDTO showDiary(Long userId, Date diaryDate) throws ParseException {
+    public DiaryShowDetailResponseDTO showDiary(Long userId, Date diaryDate) throws Exception {
         log.info("[DiaryService.showDiary]");
         return diaryRepository.showDiaryDetail(userId, diaryDate);
     }

--- a/src/main/java/com/kuit/chatdiary/service/chat/SenderService.java
+++ b/src/main/java/com/kuit/chatdiary/service/chat/SenderService.java
@@ -1,86 +1,76 @@
 package com.kuit.chatdiary.service.chat;
 
 import com.kuit.chatdiary.domain.Sender;
-import com.kuit.chatdiary.dto.chat.ChatSenderStaticResponseDTO;
+import com.kuit.chatdiary.dto.chat.ChatSenderDetailResponseDTO;
+import com.kuit.chatdiary.dto.chat.ChatSenderStatisticsResponseDTO;
 import com.kuit.chatdiary.dto.diary.DateRangeDTO;
 import com.kuit.chatdiary.repository.statics.SenderRepository;
 import org.springframework.stereotype.Service;
 
 import java.sql.Date;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 public class SenderService {
 
-    public final SenderRepository senderRepository;
+    private final SenderRepository senderRepository;
 
     public SenderService(SenderRepository senderRepository) {
         this.senderRepository = senderRepository;
     }
-    public List<ChatSenderStaticResponseDTO> calculateSenderStatistics(Long memberId, Date startDate, Date endDate) {
+    public ChatSenderStatisticsResponseDTO calculateSenderStatistics(Long memberId, Date startDate, Date endDate) {
         List<Object[]> chatStatistics = senderRepository.countChatsBySenderAndDate(memberId, startDate, endDate);
-        /** USER가 Sender이면 계산 안하기  */
-        long totalChats = chatStatistics.stream()
-                .filter(e -> !Sender.USER.name().equals(e[0]))
-                .mapToLong(e -> (Long) e[1])
-                .sum();
 
-        List<ChatSenderStaticResponseDTO> statisticsList = new ArrayList<>();
+        Map<Sender, Long> chatCountMap = new EnumMap<>(Sender.class);
+        long totalChats = 0;
         for (Object[] result : chatStatistics) {
-            Sender sender;
-            if (result[0] instanceof String) {
-                sender = Sender.valueOf((String) result[0]);//enum 으로 변환해서 사용
-            } else {
-                continue;
-            }
+            Sender sender = Sender.valueOf((String) result[0]);
             Long count = (Long) result[1];
-            double percentage = calculatePercent(count, totalChats);
-            statisticsList.add(new ChatSenderStaticResponseDTO(sender, count, percentage, startDate, endDate));
+            if (sender != Sender.USER) { /** USER가 아닌 경우에만 처리 */
+                chatCountMap.merge(sender, count, Long::sum);
+                totalChats += count;
+            }
         }
-        return statisticsList;
+
+        final long finalTotalChats = totalChats;
+        List<ChatSenderDetailResponseDTO> details = chatCountMap.entrySet().stream()
+                .filter(entry -> entry.getKey() != Sender.USER)
+                .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder())) /** 정렬 */
+                .map(entry -> new ChatSenderDetailResponseDTO(entry.getKey(), entry.getValue(), calculatePercent(entry.getValue(), finalTotalChats)))
+                .collect(Collectors.toList());
+
+        return new ChatSenderStatisticsResponseDTO(startDate, endDate, details);
     }
 
-    /** 나중에 메서드 합쳐서 리펙토링 필요 */
-    public double calculatePercent(long count,long totalTags){
-        double percentage = (double) count / totalTags * 100;
-        return Math.round(percentage*10)/10.0;
+    private double calculatePercent(long count, long totalChats) {
+        if (totalChats == 0) return 0.0;
+        return Math.round((double) count / totalChats * 1000) / 10.0;
     }
 
-    /** 나중에 메서드 합쳐서 리펙토링 필요 */
-    public DateRangeDTO staticsType(String type, LocalDate localDate){
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTime(java.sql.Date.valueOf(localDate));
-        Date startDate, endDate;
+    public DateRangeDTO staticsType(String type) {
+        LocalDate now = LocalDate.now();
+        LocalDate startDate;
+        LocalDate endDate;
+
         switch (type) {
             case "weekly":
-                /** 주간 -> 해당 주의 시작일과 종료일을 계산 */
-                calendar.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY);
-                startDate = new Date(calendar.getTimeInMillis());
-                calendar.add(Calendar.DAY_OF_WEEK, 6);
-                endDate = new Date(calendar.getTimeInMillis());
+                startDate = now.with(java.time.DayOfWeek.MONDAY);
+                endDate = now.with(java.time.DayOfWeek.SUNDAY);
                 break;
             case "monthly":
-                /** 월간 -> 해당 월의 시작일과 종료일을 계산 */
-                calendar.set(Calendar.DAY_OF_MONTH, 1);
-                startDate = new Date(calendar.getTimeInMillis());
-                calendar.add(Calendar.MONTH, 1);
-                calendar.add(Calendar.DAY_OF_MONTH, -1);
-                endDate = new Date(calendar.getTimeInMillis());
+                startDate = now.withDayOfMonth(1);
+                endDate = now.withDayOfMonth(now.lengthOfMonth());
                 break;
             case "yearly":
-                /** 연간 -> 해당 연도의 시작일과 종료일을 계산 */
-                calendar.set(Calendar.DAY_OF_YEAR, 1);
-                startDate = new Date(calendar.getTimeInMillis());
-                calendar.add(Calendar.YEAR, 1);
-                calendar.add(Calendar.DAY_OF_YEAR, -1);
-                endDate = new Date(calendar.getTimeInMillis());
+                startDate = now.withDayOfYear(1);
+                endDate = now.withDayOfYear(now.lengthOfYear());
                 break;
             default:
                 throw new IllegalArgumentException("Invalid type: " + type);
         }
-        return new DateRangeDTO(startDate, endDate);
+
+        return new DateRangeDTO(Date.valueOf(startDate), Date.valueOf(endDate));
     }
 }

--- a/src/main/java/com/kuit/chatdiary/service/chat/SenderService.java
+++ b/src/main/java/com/kuit/chatdiary/service/chat/SenderService.java
@@ -1,0 +1,86 @@
+package com.kuit.chatdiary.service.chat;
+
+import com.kuit.chatdiary.domain.Sender;
+import com.kuit.chatdiary.dto.chat.ChatSenderStaticResponseDTO;
+import com.kuit.chatdiary.dto.diary.DateRangeDTO;
+import com.kuit.chatdiary.repository.statics.SenderRepository;
+import org.springframework.stereotype.Service;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+
+@Service
+public class SenderService {
+
+    public final SenderRepository senderRepository;
+
+    public SenderService(SenderRepository senderRepository) {
+        this.senderRepository = senderRepository;
+    }
+    public List<ChatSenderStaticResponseDTO> calculateSenderStatistics(Long memberId, Date startDate, Date endDate) {
+        List<Object[]> chatStatistics = senderRepository.countChatsBySenderAndDate(memberId, startDate, endDate);
+        /** USER가 Sender이면 계산 안하기  */
+        long totalChats = chatStatistics.stream()
+                .filter(e -> !Sender.USER.name().equals(e[0]))
+                .mapToLong(e -> (Long) e[1])
+                .sum();
+
+        List<ChatSenderStaticResponseDTO> statisticsList = new ArrayList<>();
+        for (Object[] result : chatStatistics) {
+            Sender sender;
+            if (result[0] instanceof String) {
+                sender = Sender.valueOf((String) result[0]);//enum 으로 변환해서 사용
+            } else {
+                continue;
+            }
+            Long count = (Long) result[1];
+            double percentage = calculatePercent(count, totalChats);
+            statisticsList.add(new ChatSenderStaticResponseDTO(sender, count, percentage, startDate, endDate));
+        }
+        return statisticsList;
+    }
+
+    /** 나중에 메서드 합쳐서 리펙토링 필요 */
+    public double calculatePercent(long count,long totalTags){
+        double percentage = (double) count / totalTags * 100;
+        return Math.round(percentage*10)/10.0;
+    }
+
+    /** 나중에 메서드 합쳐서 리펙토링 필요 */
+    public DateRangeDTO staticsType(String type, LocalDate localDate){
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(java.sql.Date.valueOf(localDate));
+        Date startDate, endDate;
+        switch (type) {
+            case "weekly":
+                /** 주간 -> 해당 주의 시작일과 종료일을 계산 */
+                calendar.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY);
+                startDate = new Date(calendar.getTimeInMillis());
+                calendar.add(Calendar.DAY_OF_WEEK, 6);
+                endDate = new Date(calendar.getTimeInMillis());
+                break;
+            case "monthly":
+                /** 월간 -> 해당 월의 시작일과 종료일을 계산 */
+                calendar.set(Calendar.DAY_OF_MONTH, 1);
+                startDate = new Date(calendar.getTimeInMillis());
+                calendar.add(Calendar.MONTH, 1);
+                calendar.add(Calendar.DAY_OF_MONTH, -1);
+                endDate = new Date(calendar.getTimeInMillis());
+                break;
+            case "yearly":
+                /** 연간 -> 해당 연도의 시작일과 종료일을 계산 */
+                calendar.set(Calendar.DAY_OF_YEAR, 1);
+                startDate = new Date(calendar.getTimeInMillis());
+                calendar.add(Calendar.YEAR, 1);
+                calendar.add(Calendar.DAY_OF_YEAR, -1);
+                endDate = new Date(calendar.getTimeInMillis());
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid type: " + type);
+        }
+        return new DateRangeDTO(startDate, endDate);
+    }
+}

--- a/src/main/java/com/kuit/chatdiary/service/diary/DiaryStreakService.java
+++ b/src/main/java/com/kuit/chatdiary/service/diary/DiaryStreakService.java
@@ -1,0 +1,24 @@
+package com.kuit.chatdiary.service.diary;
+
+import com.kuit.chatdiary.dto.diary.DiaryStreakResponseDTO;
+import com.kuit.chatdiary.repository.diary.DiaryStreakRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+public class DiaryStreakService {
+    public final DiaryStreakRepository diaryStreakRepository;
+
+    public DiaryStreakService(DiaryStreakRepository diaryStreakRepository) {
+        this.diaryStreakRepository = diaryStreakRepository;
+    }
+
+    public DiaryStreakResponseDTO streakDate(long userId){
+        LocalDate today=LocalDate.now();
+        long streakDate=diaryStreakRepository.streakDate(userId,today);
+        DiaryStreakResponseDTO response = new DiaryStreakResponseDTO(streakDate);
+        return response;
+    }
+
+}

--- a/src/main/java/com/kuit/chatdiary/service/diary/DiaryTagStatisticsService.java
+++ b/src/main/java/com/kuit/chatdiary/service/diary/DiaryTagStatisticsService.java
@@ -2,6 +2,7 @@ package com.kuit.chatdiary.service.diary;
 
 import com.kuit.chatdiary.dto.diary.DateRangeDTO;
 import com.kuit.chatdiary.dto.diary.TagStatisticResponseDTO;
+import com.kuit.chatdiary.dto.diary.TagStatisticsWithDateResponseDTO;
 import com.kuit.chatdiary.repository.diary.DiaryTagRepository;
 import org.springframework.stereotype.Service;
 
@@ -18,23 +19,41 @@ public class DiaryTagStatisticsService {
         this.diaryTagRepository = diaryTagRepository;
     }
 
-    public List<TagStatisticResponseDTO> calculateTagStatistics(Long memberId, Date startDate, Date endDate) {
-        List<Object[]> tagStatistics = diaryTagRepository.findTagStatisticsByMember(memberId, startDate, endDate);
-        /** 쿼리 3번째 결과를 추출해서 스트림으로 탐색해서 다 더해서 전체 카운트 계산..! */
-        long totalTags = tagStatistics.stream().mapToLong(e -> (Long) e[2]).sum();
+    /** TagStatisticsWithDateDTO로 수정 */
+    public TagStatisticsWithDateResponseDTO calculateTagStatistics(Long memberId, String type) {
+        LocalDate localDate = LocalDate.now();
+        DateRangeDTO dateRange = calculateDateRangeBasedOnType(type, localDate);
+        List<Object[]> tagStatistics = diaryTagRepository.findTagStatisticsByMember(memberId, dateRange.getStartDate(), dateRange.getEndDate());
+        long totalTags = calculateTotalTags(tagStatistics);
+        List<TagStatisticResponseDTO> statisticsList = buildStatisticsList(tagStatistics, totalTags);
+        sortStatisticsListByCount(statisticsList);
+        return new TagStatisticsWithDateResponseDTO(dateRange.getStartDate(), dateRange.getEndDate(), statisticsList);
+    }
+
+    /** 타입별로 나눠서 계산 */
+    private DateRangeDTO calculateDateRangeBasedOnType(String type, LocalDate date) {
+        return staticsType(type, date);
+    }
+
+    /** 전체 계산 다 더하기 */
+    private long calculateTotalTags(List<Object[]> tagStatistics) {
+        return tagStatistics.stream().mapToLong(e -> (Long) e[2]).sum();
+    }
+
+    private List<TagStatisticResponseDTO> buildStatisticsList(List<Object[]> tagStatistics, long totalTags) {
         List<TagStatisticResponseDTO> statisticsList = new ArrayList<>();
         for (Object[] result : tagStatistics) {
             String category = (String) result[0];
             String tagName = (String) result[1];
             Long count = (Long) result[2];
-            statisticsList.add(new TagStatisticResponseDTO(category, tagName, count, calculatePercent(count, totalTags), startDate, endDate));
+            statisticsList.add(new TagStatisticResponseDTO(category, tagName, count, calculatePercent(count, totalTags)));
         }
-
-        statisticsList.sort((o1, o2) -> {
-            return (int) (o2.getCount() - o1.getCount());
-        });
-
         return statisticsList;
+    }
+
+    /** 정렬 메서드 */
+    private void sortStatisticsListByCount(List<TagStatisticResponseDTO> statisticsList) {
+        statisticsList.sort(Comparator.comparingLong(TagStatisticResponseDTO::getCount).reversed());
     }
 
     public double calculatePercent(long count,long totalTags){
@@ -44,36 +63,26 @@ public class DiaryTagStatisticsService {
 
     /** 코드 더 줄이고 싶은데.. */
     public DateRangeDTO staticsType(String type, LocalDate localDate){
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTime(java.sql.Date.valueOf(localDate));
-        Date startDate, endDate;
+        LocalDate startDate;
+        LocalDate endDate;
+
         switch (type) {
             case "weekly":
-                /** 주간 -> 해당 주의 시작일과 종료일을 계산 */
-                calendar.set(Calendar.DAY_OF_WEEK, calendar.getFirstDayOfWeek());
-                startDate = new Date(calendar.getTimeInMillis());
-                calendar.add(Calendar.DAY_OF_WEEK, 6);
-                endDate = new Date(calendar.getTimeInMillis());
+                startDate = localDate.with(java.time.DayOfWeek.MONDAY);
+                endDate = localDate.with(java.time.DayOfWeek.SUNDAY);
                 break;
             case "monthly":
-                /** 월간 -> 해당 월의 시작일과 종료일을 계산 */
-                calendar.set(Calendar.DAY_OF_MONTH, 1);
-                startDate = new Date(calendar.getTimeInMillis());
-                calendar.add(Calendar.MONTH, 1);
-                calendar.add(Calendar.DAY_OF_MONTH, -1);
-                endDate = new Date(calendar.getTimeInMillis());
+                startDate = localDate.withDayOfMonth(1);
+                endDate = localDate.withDayOfMonth(localDate.lengthOfMonth());
                 break;
             case "yearly":
-                /** 연간 -> 해당 연도의 시작일과 종료일을 계산 */
-                calendar.set(Calendar.DAY_OF_YEAR, 1);
-                startDate = new Date(calendar.getTimeInMillis());
-                calendar.add(Calendar.YEAR, 1);
-                calendar.add(Calendar.DAY_OF_YEAR, -1);
-                endDate = new Date(calendar.getTimeInMillis());
+                startDate = localDate.withDayOfYear(1);
+                endDate = localDate.withDayOfYear(localDate.lengthOfYear());
                 break;
             default:
                 throw new IllegalArgumentException("Invalid type: " + type);
         }
-        return new DateRangeDTO(startDate, endDate);
+
+        return new DateRangeDTO(Date.valueOf(startDate), Date.valueOf(endDate));
     }
 }

--- a/src/main/java/com/kuit/chatdiary/service/diary/TagPoolService.java
+++ b/src/main/java/com/kuit/chatdiary/service/diary/TagPoolService.java
@@ -1,0 +1,23 @@
+package com.kuit.chatdiary.service.diary;
+
+import com.kuit.chatdiary.domain.Tag;
+import com.kuit.chatdiary.dto.diary.TagPoolResponseDTO;
+import com.kuit.chatdiary.repository.diary.TagPoolRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class TagPoolService {
+
+    private final TagPoolRepository tagPoolRepository;
+
+    public TagPoolService(TagPoolRepository tagPoolRepository) {
+        this.tagPoolRepository = tagPoolRepository;
+    }
+
+    public List<TagPoolResponseDTO> getTagPool(){
+        return tagPoolRepository.findAllTags();
+    }
+
+}

--- a/src/main/java/com/kuit/chatdiary/service/diary/TagSearchService.java
+++ b/src/main/java/com/kuit/chatdiary/service/diary/TagSearchService.java
@@ -12,8 +12,8 @@ public class TagSearchService {
     public TagSearchService(TagSearchRepository tagSearchRepository) {
         this.tagSearchRepository = tagSearchRepository;
     }
-    public List<TagSearchResponseDTO> findByTag(List<String> tagNames){
-        return tagSearchRepository.findByTag(tagNames);
+    public List<TagSearchResponseDTO> findByTag(List<String> tagNames,long userId){
+        return tagSearchRepository.findByTag(tagNames,userId);
     }
 
 }


### PR DESCRIPTION
응답에 조회일에 가장 채팅을 많이한 캐릭터의 인덱스 추가 (DADA:1, CHICHI: 2, LULU:3)

## 요약 (Summary)
<!-- 작업한 부분에 대한 간단한 요약을 작성하세요. -->
- [x] 일기 상세조회의 응답에 캐릭터 인덱스 추가

## 변경 사항 (Changes)
<!-- 기존과 비교했을 때 해당 PR에서 변경된 내용을 작성하세요. -->
<!-- 어떤 부분을 왜 수정했는지 구체적으로 기술하세요. -->
- 기존 156-일기상세 브랜치의 응답에 채팅을 가장 많이한 캐릭터의 인덱스 추가 반환
- DiaryRepository 수정
- <간단한 로직 설명>
- 1. GROUP BY, ORDER BY로 해당 날짜에 대화한 캐릭터, 대화 수를 내림차순으로 조회
- 2. 대화수 1등이 하나인경우 -> 그 캐릭터로 반환
- 3. 공동 1등이 있는경우 -> 캐릭터 중 랜덤으로 반환

* 공동 1등인경우 랜덤으로 반환되는데 이러면 조회할때마다 캐릭터수가 달라진다는 단점(?)이 존재합니다.

[수정]
1. 같은 갯수의 채팅을 한 경우 최근 채팅한 캐릭터의 인덱스 반환 (DiaryRepository의 **showDiaryDetail**() 수정)
2. 없는 일기 조회시 오류 발생
3. domain 에서 text가 되어야하는것 @Column(columnDefinition = "TEXT") 추가(Member의 email, Photo의 image_url)

## 리뷰 요구사항
<!-- 해당 PR에서 중점적으로 혹은 꼭 리뷰가 필요한 사항들을 작성하세요. --> 
<!-- 체크리스트, 특별한 주의 사항 등 자유 형식으로 기술하세요. -->
- [x] 쿼리문이 정확하게 짜였는지
- [ ] 공동 1등인경우에 대한 아이디어? 가 적절한지(아이디어 받습니다아ㅏ)
- [x] 기존 응답에 추가되어 잘 나오는지

## 확인 방법 (선택)
<!-- UI 구현 화면의 스크린샷, 기능 작동 스크린샷 등 작업 결과를 한 눈에 볼 수 있는 자료를 첨부하세요. -->
기존과 마찬가지로 POSTMAN을 활용하면 됩니다.
마지막에 characterIndex 만 추가한것이니 저 부분만 확인해주세욤
![image](https://github.com/Chat-Diary/BE/assets/81453127/24b99430-a3d6-41af-b107-0add64262c0f)

http://localhost:8080/diary/detail?user_id=1&diary_date=2024-01-02