### PR TITLE
Feat: CHAT-260-BE-API-대화-상대-통계-수정

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "develop" ]
   pull_request:
-    branches: [ "develop" ]
+    branches: [  ]
 
 permissions:
   contents: read

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -61,9 +61,9 @@ jobs:
           --build-arg REGION=${{ secrets.REGION }} \
           --build-arg ACCESS_KEY=${{ secrets.ACCESS_KEY }} \
           --build-arg SECRET_KEY=${{ secrets.SECRET_KEY }} \
-          -t chatdiary/chatdiary-image:latest .
+          -t ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPO_NAME }} .
           docker images
-          docker push chatdiary/chatdiary-image:latest
+          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPO_NAME }}
 
       - name: deploy
         uses: appleboy/ssh-action@master

--- a/src/main/java/com/kuit/chatdiary/controller/SenderController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/SenderController.java
@@ -26,9 +26,8 @@ public class SenderController {
     @GetMapping("/sender")
     public ResponseEntity<List<ChatSenderStaticResponseDTO>> getTagStatistics(
             @RequestParam("memberId") Long memberId,
-            @RequestParam("type") String type,
-            @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate localDate) {
-        DateRangeDTO dateRange = senderService.staticsType(type,localDate);
+            @RequestParam("type") String type){
+        DateRangeDTO dateRange = senderService.staticsType(type);
         List<ChatSenderStaticResponseDTO> tagStatistics = senderService.calculateSenderStatistics(memberId, dateRange.getStartDate()
                 ,dateRange.getEndDate());
         return ResponseEntity.ok(tagStatistics);

--- a/src/main/java/com/kuit/chatdiary/controller/SenderController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/SenderController.java
@@ -1,17 +1,13 @@
 package com.kuit.chatdiary.controller;
 
-import com.kuit.chatdiary.dto.chat.ChatSenderStaticResponseDTO;
+import com.kuit.chatdiary.dto.chat.ChatSenderStatisticsResponseDTO;
 import com.kuit.chatdiary.dto.diary.DateRangeDTO;
 import com.kuit.chatdiary.service.chat.SenderService;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.time.LocalDate;
-import java.util.List;
 
 @RestController
 @RequestMapping("/chat")
@@ -24,13 +20,12 @@ public class SenderController {
     }
 
     @GetMapping("/sender")
-    public ResponseEntity<List<ChatSenderStaticResponseDTO>> getTagStatistics(
+    public ResponseEntity<ChatSenderStatisticsResponseDTO> getSenderStatistics(
             @RequestParam("memberId") Long memberId,
-            @RequestParam("type") String type){
+            @RequestParam("type") String type) {
         DateRangeDTO dateRange = senderService.staticsType(type);
-        List<ChatSenderStaticResponseDTO> tagStatistics = senderService.calculateSenderStatistics(memberId, dateRange.getStartDate()
-                ,dateRange.getEndDate());
-        return ResponseEntity.ok(tagStatistics);
+        ChatSenderStatisticsResponseDTO senderStatistics = senderService.calculateSenderStatistics(memberId, dateRange.getStartDate(), dateRange.getEndDate());
+        return ResponseEntity.ok(senderStatistics);
     }
 
 }

--- a/src/main/java/com/kuit/chatdiary/dto/chat/ChatSenderDetailResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/chat/ChatSenderDetailResponseDTO.java
@@ -1,0 +1,17 @@
+package com.kuit.chatdiary.dto.chat;
+
+import com.kuit.chatdiary.domain.Sender;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatSenderDetailResponseDTO {
+    private Sender sender;
+    private Long chatCount;
+    private double percentage;
+}

--- a/src/main/java/com/kuit/chatdiary/dto/chat/ChatSenderStaticResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/chat/ChatSenderStaticResponseDTO.java
@@ -7,15 +7,14 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.sql.Date;
+import java.util.List;
+
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChatSenderStaticResponseDTO {
-
-    private Sender sender;
-    private Long chatCount;
-    private double percentage;
     private Date startDate;
     private Date endDate;
+    private List<ChatSenderStaticResponseDTO> statistics;
 }

--- a/src/main/java/com/kuit/chatdiary/dto/chat/ChatSenderStatisticsResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/chat/ChatSenderStatisticsResponseDTO.java
@@ -1,6 +1,5 @@
 package com.kuit.chatdiary.dto.chat;
 
-import com.kuit.chatdiary.domain.Sender;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,8 +12,8 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class ChatSenderStaticResponseDTO {
+public class ChatSenderStatisticsResponseDTO {
     private Date startDate;
     private Date endDate;
-    private List<ChatSenderStaticResponseDTO> statistics;
+    private List<ChatSenderDetailResponseDTO> statistics;
 }

--- a/src/main/java/com/kuit/chatdiary/service/chat/SenderService.java
+++ b/src/main/java/com/kuit/chatdiary/service/chat/SenderService.java
@@ -35,7 +35,7 @@ public class SenderService {
         final long finalTotalChats = totalChats;
         List<ChatSenderDetailResponseDTO> details = chatCountMap.entrySet().stream()
                 .filter(entry -> entry.getKey() != Sender.USER)
-                .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
+                .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder())) /** 정렬 */
                 .map(entry -> new ChatSenderDetailResponseDTO(entry.getKey(), entry.getValue(), calculatePercent(entry.getValue(), finalTotalChats)))
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/kuit/chatdiary/service/chat/SenderService.java
+++ b/src/main/java/com/kuit/chatdiary/service/chat/SenderService.java
@@ -28,8 +28,10 @@ public class SenderService {
         for (Object[] result : chatStatistics) {
             Sender sender = Sender.valueOf((String) result[0]);
             Long count = (Long) result[1];
-            chatCountMap.merge(sender, count, Long::sum);
-            totalChats += count;
+            if (sender != Sender.USER) { /** USER가 아닌 경우에만 처리 */
+                chatCountMap.merge(sender, count, Long::sum);
+                totalChats += count;
+            }
         }
 
         final long finalTotalChats = totalChats;

--- a/src/main/java/com/kuit/chatdiary/service/chat/SenderService.java
+++ b/src/main/java/com/kuit/chatdiary/service/chat/SenderService.java
@@ -1,7 +1,8 @@
 package com.kuit.chatdiary.service.chat;
 
 import com.kuit.chatdiary.domain.Sender;
-import com.kuit.chatdiary.dto.chat.ChatSenderStaticResponseDTO;
+import com.kuit.chatdiary.dto.chat.ChatSenderDetailResponseDTO;
+import com.kuit.chatdiary.dto.chat.ChatSenderStatisticsResponseDTO;
 import com.kuit.chatdiary.dto.diary.DateRangeDTO;
 import com.kuit.chatdiary.repository.statics.SenderRepository;
 import org.springframework.stereotype.Service;
@@ -9,88 +10,65 @@ import org.springframework.stereotype.Service;
 import java.sql.Date;
 import java.time.LocalDate;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 public class SenderService {
 
-    public final SenderRepository senderRepository;
+    private final SenderRepository senderRepository;
 
     public SenderService(SenderRepository senderRepository) {
         this.senderRepository = senderRepository;
     }
-    public List<ChatSenderStaticResponseDTO> calculateSenderStatistics(Long memberId, Date startDate, Date endDate) {
+    public ChatSenderStatisticsResponseDTO calculateSenderStatistics(Long memberId, Date startDate, Date endDate) {
         List<Object[]> chatStatistics = senderRepository.countChatsBySenderAndDate(memberId, startDate, endDate);
 
-        /** value를 count로 활용해서 연산 쉽게 */
-        Map<Sender, Long> chatCountMap = new HashMap<>();
+        Map<Sender, Long> chatCountMap = new EnumMap<>(Sender.class);
         long totalChats = 0;
         for (Object[] result : chatStatistics) {
-            String senderName = (String) result[0];
+            Sender sender = Sender.valueOf((String) result[0]);
             Long count = (Long) result[1];
-
-            if (!senderName.equals(Sender.USER.name())) {
-                Sender sender = Sender.valueOf(senderName);
-                chatCountMap.put(sender, count);
-                totalChats += count;
-            }
-        }
-        /** 이미 키 있으면 업데이트 안하기
-         * 0개 처리
-         * */
-        for (Sender sender : Sender.values()) {
-            chatCountMap.putIfAbsent(sender, 0L);
+            chatCountMap.merge(sender, count, Long::sum);
+            totalChats += count;
         }
 
-        List<ChatSenderStaticResponseDTO> statisticsList = new ArrayList<>();
-        for (Map.Entry<Sender, Long> entry : chatCountMap.entrySet()) {
-            if (entry.getKey() != Sender.USER) {
-                double percentage = calculatePercent(entry.getValue(), totalChats);
-                statisticsList.add(new ChatSenderStaticResponseDTO(entry.getKey(), entry.getValue(), percentage, startDate, endDate));
-            }
-        }
+        final long finalTotalChats = totalChats;
+        List<ChatSenderDetailResponseDTO> details = chatCountMap.entrySet().stream()
+                .filter(entry -> entry.getKey() != Sender.USER)
+                .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
+                .map(entry -> new ChatSenderDetailResponseDTO(entry.getKey(), entry.getValue(), calculatePercent(entry.getValue(), finalTotalChats)))
+                .collect(Collectors.toList());
 
-        return statisticsList;
+        return new ChatSenderStatisticsResponseDTO(startDate, endDate, details);
     }
 
-    /** 나중에 메서드 합쳐서 리펙토링 필요 */
-    public double calculatePercent(long count,long totalTags){
-        double percentage = (double) count / totalTags * 100;
-        return Math.round(percentage*10)/10.0;
+    private double calculatePercent(long count, long totalChats) {
+        if (totalChats == 0) return 0.0;
+        return Math.round((double) count / totalChats * 1000) / 10.0;
     }
 
-    /** 나중에 메서드 합쳐서 리펙토링 필요 */
-    public DateRangeDTO staticsType(String type){
-        LocalDate localDate = LocalDate.now();
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTime(java.sql.Date.valueOf(localDate));
-        Date startDate, endDate;
+    public DateRangeDTO staticsType(String type) {
+        LocalDate now = LocalDate.now();
+        LocalDate startDate;
+        LocalDate endDate;
+
         switch (type) {
             case "weekly":
-                /** 주간 -> 해당 주의 시작일과 종료일을 계산 */
-                calendar.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY);
-                startDate = new Date(calendar.getTimeInMillis());
-                calendar.add(Calendar.DAY_OF_WEEK, 6);
-                endDate = new Date(calendar.getTimeInMillis());
+                startDate = now.with(java.time.DayOfWeek.MONDAY);
+                endDate = now.with(java.time.DayOfWeek.SUNDAY);
                 break;
             case "monthly":
-                /** 월간 -> 해당 월의 시작일과 종료일을 계산 */
-                calendar.set(Calendar.DAY_OF_MONTH, 1);
-                startDate = new Date(calendar.getTimeInMillis());
-                calendar.add(Calendar.MONTH, 1);
-                calendar.add(Calendar.DAY_OF_MONTH, -1);
-                endDate = new Date(calendar.getTimeInMillis());
+                startDate = now.withDayOfMonth(1);
+                endDate = now.withDayOfMonth(now.lengthOfMonth());
                 break;
             case "yearly":
-                /** 연간 -> 해당 연도의 시작일과 종료일을 계산 */
-                calendar.set(Calendar.DAY_OF_YEAR, 1);
-                startDate = new Date(calendar.getTimeInMillis());
-                calendar.add(Calendar.YEAR, 1);
-                calendar.add(Calendar.DAY_OF_YEAR, -1);
-                endDate = new Date(calendar.getTimeInMillis());
+                startDate = now.withDayOfYear(1);
+                endDate = now.withDayOfYear(now.lengthOfYear());
                 break;
             default:
                 throw new IllegalArgumentException("Invalid type: " + type);
         }
-        return new DateRangeDTO(startDate, endDate);
+
+        return new DateRangeDTO(Date.valueOf(startDate), Date.valueOf(endDate));
     }
 }

--- a/src/main/java/com/kuit/chatdiary/service/chat/SenderService.java
+++ b/src/main/java/com/kuit/chatdiary/service/chat/SenderService.java
@@ -59,7 +59,8 @@ public class SenderService {
     }
 
     /** 나중에 메서드 합쳐서 리펙토링 필요 */
-    public DateRangeDTO staticsType(String type, LocalDate localDate){
+    public DateRangeDTO staticsType(String type){
+        LocalDate localDate = LocalDate.now();
         Calendar calendar = Calendar.getInstance();
         calendar.setTime(java.sql.Date.valueOf(localDate));
         Date startDate, endDate;


### PR DESCRIPTION
기존에 복잡한 로직 맵을 적극 사용해서 수정 및, 응답에서 USER 제외

## 요약 (Summary)
- [x] SenderService의 calculateSenderStatistics 메서드를 리팩토링하여 코드 가독성 향상
- [x] USER 타입 Sender 응답에서 제외하고, 대화하지 않은 상대를 0으로 카운트하는 로직 
- [x] 파라매터로 받는것이 아니라, 서버 시간 사용하도록 수정 

## 변경 사항 (Changes)
- Map<Sender, Long>을 사용해 Sender.USER를 제외하고, 기존의 쿼리 결과를 바탕으로 채팅 통계를 계산.(레포지 유지)
- 스트림과 조건문을 사용하여 구현.
- 리팩토링된 로직은 좀더 쉬운 for 루프와 if 조건문을 사용
- 모든 Sender에 대해 초기 카운트를 0으로 설정하고, 쿼리 결과를 통해 실제 카운트 값을 업데이트. 
- putIfAbsent 메서드를 활용해 대화하지 않은 Sender도 처리.
- calculateSenderStatistics 메서드 내의 총 챗 수 계산 방식을 단순화하여, totalChats를 바로 업데이트하도록 변경.
## 추가 변경 사항 (Changes)
- 반환하는 JSON형태 수정
- DTO 추가 작성 ( 리스트 + 날짜 정보 )



## 리뷰 요구사항
- [ ]  리팩토링된 메서드의 로직이 기존 기능을 그대로 유지하면서 코드의 가독성을 향상시키는지 검토 요청
- [ ] Sender.USER 제외 로직과 대화하지 않은 상대를 0으로 카운트하는 부분의 올바른 동작 확인 요청
- [ ] 전반적인 코드 스타일과 구조에 대한 피드백 요청

## 확인 방법 (선택)

### 예시 요청 주소
#### 주간
```
http://localhost:8080/chat/sender?memberId=1&type=weekly
```
#### 월간

```
http://localhost:8080/chat/sender?memberId=1&type=monthly
```
#### 연간

```
http://localhost:8080/chat/sender?memberId=1&type=yearly
```


### 예시 쿼리문
```
use chatdiary;
INSERT INTO member (email, password, create_at, update_at)
VALUES ("aa@aa", "123", "2024-01-28", "2024-01-28");

INSERT INTO diary (user_id, diary_date, title, content,create_at, update_at)
VALUES (1,"20240129","1title", "1content", "2024-01-29", "2024-01-29"),
(1,"20240130","2title", "2content", "2024-01-29", "2024-01-29"),
(1,"20240131","3title", "3content", "2024-01-29", "2024-01-29");

INSERT INTO chat (sender, content, chat_type, user_id, create_at)
VALUES ("CHICHI", "", "IMG", 1, "2024-01-29"),("USER", "", "IMG", 1, "2024-01-30"),("LULU", "", "CHAT", 1, "2024-02-01"),("DADA", "", "CHAT", 1, "2024-02-02"),("USER", "", "IMG", 1, "2024-02-05"),("CHICHI","", "CHAT", 1, "2024-02-11");

```

#### 요청사항
대상이 없을때체크, 이번달 (2월)이 아닌 1월에 대해서는 monthly 조회시 0으로 잘되는지 등 경계값 체크 부탁드립니다.
