### PR TITLE
Feat: CHAT-254-BE-카카오-로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,11 +27,16 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'com.google.code.gson:gson:2.8.8'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	runtimeOnly('mysql:mysql-connector-java:8.0.30')
 	runtimeOnly('com.h2database:h2')
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kuit/chatdiary/controller/Login/KakaoLogin.java
+++ b/src/main/java/com/kuit/chatdiary/controller/Login/KakaoLogin.java
@@ -1,0 +1,18 @@
+package com.kuit.chatdiary.controller.Login;
+
+import org.springframework.beans.factory.annotation.Value;
+
+public class KakaoLogin {
+
+    @Value("${KAKAO_API_KEY}")
+    private String kakaoApiKey;
+
+    @Value("${KAKAO_REDIRECT_URI}")
+    private String kakaoRedirectUri;
+
+    @Value("${S3_BUCKET}")
+    private String secretKey;
+
+
+
+}

--- a/src/main/java/com/kuit/chatdiary/controller/Login/LogInController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/Login/LogInController.java
@@ -1,0 +1,51 @@
+package com.kuit.chatdiary.controller.Login;
+
+import com.kuit.chatdiary.dto.login.KakaoLoginResponseDTO;
+import com.kuit.chatdiary.service.KakaoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.Map;
+
+@Controller
+@RequiredArgsConstructor
+public class LogInController {
+
+    @Autowired
+    public KakaoService kakaoService;
+
+
+    @GetMapping("/kakao/callback")
+    public KakaoLoginResponseDTO login(@RequestParam("code") String code) throws Exception {
+        //1. 클라이언트에서 로그인 코드를 보내줌 (서버에서 할일 X)
+        System.out.println("code: "+code);
+
+        //2. 토큰 받기
+        String accessToken = kakaoService.getAccessToken(code);
+        System.out.println("accessToken: "+accessToken);
+
+        //3. 사용자 정보 받기
+        Map<String, Object> userInfo = kakaoService.getUserInfo(accessToken);
+        String nickname = (String)userInfo.get("nickname");
+
+        System.out.println("nickname = " + nickname);
+        System.out.println("accessToken = " + accessToken);
+
+
+        if(nickname != null) {
+            //4. 사용자 정보 기반으로 jwt 생성
+            String jwt = kakaoService.generateJwt(nickname, 3600000);
+            System.out.println("jwt: "+jwt);
+
+            return new KakaoLoginResponseDTO(jwt);
+        }
+        else{
+            throw new Exception("인증되지 않은 사용자입니다");
+        }
+
+    }
+
+}

--- a/src/main/java/com/kuit/chatdiary/domain/Member.java
+++ b/src/main/java/com/kuit/chatdiary/domain/Member.java
@@ -1,10 +1,7 @@
 package com.kuit.chatdiary.domain;
 
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Cleanup;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -16,12 +13,15 @@ import java.util.List;
 
 @Entity(name = "member")
 @Getter
+@Setter
 @NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 public class Member {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY) //auto increment
     @Column(name = "user_id")
     private Long userId;
+
+    private String nickname;
 
     private String email;
 

--- a/src/main/java/com/kuit/chatdiary/dto/login/KakaoLoginResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/login/KakaoLoginResponseDTO.java
@@ -1,0 +1,14 @@
+package com.kuit.chatdiary.dto.login;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoLoginResponseDTO {
+    private String jwt;
+}

--- a/src/main/java/com/kuit/chatdiary/repository/MemberRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/MemberRepository.java
@@ -4,4 +4,5 @@ import com.kuit.chatdiary.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Member findByNickname(String nickname);
 }

--- a/src/main/java/com/kuit/chatdiary/service/KakaoService.java
+++ b/src/main/java/com/kuit/chatdiary/service/KakaoService.java
@@ -1,0 +1,128 @@
+package com.kuit.chatdiary.service;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Date;
+import java.util.HashMap;
+
+@Slf4j
+@Service
+public class KakaoService {
+
+    @Value("${KAKAO_API_KEY}")
+    private String kakaoApiKey;
+
+    @Value("${KAKAO_REDIRECT_URI}")
+    private String kakaoRedirectUri;
+
+    // AccessToken 발급하는 메서드
+    public String getAccessToken(String code) {
+        log.info("[KakaoService.getAccessToken]");
+
+        String accessToken = "";
+        String reqUrl = "https://kauth.kakao.com/oauth/token";
+
+        try{
+            URL url = new URL(reqUrl);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+            conn.setRequestMethod("POST");
+            conn.setDoOutput(true);
+
+            BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()));
+            StringBuilder sb = new StringBuilder();
+
+            sb.append("grant_type=authorization_code");
+            sb.append("&client_id=").append(kakaoApiKey);
+            sb.append("&redirect_uri=").append(kakaoRedirectUri);
+            sb.append("&code=").append(code);
+
+            bw.write(sb.toString());
+            bw.flush();
+
+            BufferedReader br;
+            br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+
+            String line = "";
+            StringBuilder responseSb = new StringBuilder();
+            while((line = br.readLine()) != null){
+                responseSb.append(line);
+            }
+            String result = responseSb.toString();
+            System.out.println("responseBody : "+result);
+
+            JsonParser parser = new JsonParser();
+            JsonElement element = parser.parse(result);
+            accessToken = element.getAsJsonObject().get("access_token").getAsString();
+
+            br.close();
+            bw.close();
+
+        }catch (Exception e){
+            e.printStackTrace();
+        }
+        return accessToken;
+    }
+
+    // 사용자 정보 가져오는 메서드
+    public HashMap<String, Object> getUserInfo(String accessToken) {
+        HashMap<String, Object> userInfo = new HashMap<>();
+        String reqUrl = "https://kapi.kakao.com/v2/user/me";
+        try{
+            URL url = new URL(reqUrl);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Authorization", "Bearer " + accessToken);
+
+            BufferedReader br;
+            br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+
+            String line = "";
+            StringBuilder responseSb = new StringBuilder();
+            while((line = br.readLine()) != null){
+                responseSb.append(line);
+            }
+            String result = responseSb.toString();
+            JsonParser parser = new JsonParser();
+            JsonElement element = parser.parse(result);
+
+            JsonObject properties = element.getAsJsonObject().get("properties").getAsJsonObject();
+            String nickname = properties.getAsJsonObject().get("nickname").getAsString();
+            userInfo.put("nickname", nickname);
+
+            br.close();
+
+        }catch (Exception e){
+            e.printStackTrace();
+        }
+        return userInfo;
+    }
+
+    // jwt 발급하는 메서드
+    public String generateJwt(String nickname, long expirationTime){
+
+        SecretKey secretKey = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+        Date expirationDate = new Date(System.currentTimeMillis() + expirationTime);
+
+        return Jwts.builder()
+                .setSubject(nickname)
+                .setExpiration(expirationDate)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+}

--- a/src/main/java/com/kuit/chatdiary/service/LogInService.java
+++ b/src/main/java/com/kuit/chatdiary/service/LogInService.java
@@ -3,10 +3,13 @@ package com.kuit.chatdiary.service;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.kuit.chatdiary.domain.Member;
+import com.kuit.chatdiary.repository.MemberRepository;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -22,13 +25,20 @@ import java.util.HashMap;
 
 @Slf4j
 @Service
-public class KakaoService {
+public class LogInService {
+
+    @Autowired
+    private final MemberRepository memberRepository;
 
     @Value("${KAKAO_API_KEY}")
     private String kakaoApiKey;
 
     @Value("${KAKAO_REDIRECT_URI}")
     private String kakaoRedirectUri;
+
+    public LogInService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
 
     // AccessToken 발급하는 메서드
     public String getAccessToken(String code) {
@@ -124,5 +134,33 @@ public class KakaoService {
                 .setExpiration(expirationDate)
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
+    }
+
+    public Boolean isMember(String nickname) {
+        Member member = memberRepository.findByNickname(nickname);
+        if(member==null){
+            return false;
+        }
+        return true;
+    }
+
+    public void saveMember(String nickname) {
+        //이메일, 패스워드는 막넣음
+        String defaultEmail = nickname+"@"+nickname;
+        String defaultPassword = nickname+"123";
+
+        Member member = new Member();
+        member.setNickname(nickname);
+        member.setEmail(defaultEmail);
+        member.setPassword(defaultPassword);
+
+        memberRepository.save(member);
+
+        if(member.getUserId() !=null){
+            log.info("가입 완료!");
+        }else{
+            log.info("가입 실패!");
+        }
+
     }
 }


### PR DESCRIPTION
## 요약 (Summary)
<!-- 작업한 부분에 대한 간단한 요약을 작성하세요. -->
- [x] 카카오 소셜 로그인

## 변경 사항 (Changes)
<!-- 기존과 비교했을 때 해당 PR에서 변경된 내용을 작성하세요. -->
<!-- 어떤 부분을 왜 수정했는지 구체적으로 기술하세요. -->
- LoginController, KakaoLogin, KakaoLoginResponseDTO, KakaoService 클래스 작성
- <간단한 로직 설명>
- 1. 클라이언트에서 카카오 로그인 -> 카카오 회원이 맞을시 redirectUri로 인가코드(code) 보내줌
- 2. redirect uri로 접속
- 3. access Token 받아옴 (KakaService의 **getAccessToken**())
- 4. access Token으로 사용자 정보 받아옴 (KakaService의 **getUserInfo**())
- 5. 받아온 정보로 jwt 생성(KakaService의 **generateJwt**()) 후 응답에 jwt 담아 전송
[추가 변경사항]
- nickname은 중복되지 않는다고 가정하고 진행했습니다.
- Member 도메인에 nickname 변수 추가
- 가입된 사용자인지 여부에따라 **로그인** or **회원가입 후 로그인** 으로 분리 (가입 여부는 위 4번의 사용자 정보(nickname)로 판단)

## 리뷰 요구사항
<!-- 해당 PR에서 중점적으로 혹은 꼭 리뷰가 필요한 사항들을 작성하세요. --> 
<!-- 체크리스트, 특별한 주의 사항 등 자유 형식으로 기술하세요. -->
- [ ]카카오 로그인 했을때 jwt값이 잘 반환되는지 확인
- [ ]소셜 로그인 로직이 맞는지(빼먹은 단계는 없는지&jwt반환하는게 맞는 방법인지)

## 확인 방법 (선택)
<!-- UI 구현 화면의 스크린샷, 기능 작동 스크린샷 등 작업 결과를 한 눈에 볼 수 있는 자료를 첨부하세요. -->
1. kauth.kakao.com/oauth/authorize?client_id={REST_API}e&redirect_uri={REDIRECT_URI}&response_type=code
크롬에서 이 url 주소로 접속하고 챗다이어리 계정을 입력해줍니다. 사파리 안됨 크롬이여야함! (rest_api, redirect_uri 값은 카카오 디벨로퍼에서 확인 가능합니다. 귀찮으면 디엠주세오)
->혹시 chatdiray 계정이 아니라 본인 계정으로 접속된다? 하면 시크릿창 열어서 해보세용
<img width="711" alt="image" src="https://github.com/Chat-Diary/BE/assets/81453127/aebdacba-979f-44dd-8464-c9fd6a8dcdb0">



2. 로그인을 누르면 인텔리제이에서 결과를 확인할 수 있습니다.
<img width="1182" alt="image" src="https://github.com/Chat-Diary/BE/assets/81453127/921a73ed-9da1-4036-8040-0f71571a970f">



3.(추가) nickname이 가입된 사용자이면 바로 jwt 반환, 미가입 사용자이면 회원가입 후 jwt반환됩니다.
-> db에서 확인 가능합니다

마지막에 jwt가 잘 생성돼서 반환되는지 확인해주시면 됩니다!
+ postman으로 테스트하고싶은데 인가코드 받는거랑 나머지 기능(토큰발급, 사용자 정보 받기, jwt생성)을 분리해야돼서 인텔리제이로 확인하는 방법으로 진행했습니다. postman 테스트로 바꿔야된다고 생각하시면 알려주세요!
