### PR TITLE
Feat : CHAT-257-BE-공지사항-리스트&상세

### DIFF
--- a/src/main/java/com/kuit/chatdiary/controller/notice/NoticeController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/notice/NoticeController.java
@@ -1,6 +1,7 @@
 package com.kuit.chatdiary.controller.notice;
 
 import com.kuit.chatdiary.dto.diary.TagPoolResponseDTO;
+import com.kuit.chatdiary.dto.notice.NoticeListResponseDTO;
 import com.kuit.chatdiary.dto.notice.NoticeResponseDTO;
 import com.kuit.chatdiary.service.notice.NoticeService;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +21,7 @@ public class NoticeController {
     private final NoticeService noticeService;
 
     @GetMapping("/list")
-    public ResponseEntity<List<NoticeResponseDTO>> getNoticeList(){
+    public ResponseEntity<List<NoticeListResponseDTO>> getNoticeList(){
         return ResponseEntity.ok(noticeService.findNotices());
     }
 

--- a/src/main/java/com/kuit/chatdiary/controller/notice/NoticeController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/notice/NoticeController.java
@@ -1,0 +1,33 @@
+package com.kuit.chatdiary.controller.notice;
+
+import com.kuit.chatdiary.dto.diary.TagPoolResponseDTO;
+import com.kuit.chatdiary.dto.notice.NoticeResponseDTO;
+import com.kuit.chatdiary.service.notice.NoticeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("notice")
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @GetMapping("/list")
+    public ResponseEntity<List<NoticeResponseDTO>> getNoticeList(){
+        return ResponseEntity.ok(noticeService.findNotices());
+    }
+
+    @GetMapping("/detail")
+    public ResponseEntity<NoticeResponseDTO> getNoticeList(@RequestParam("noticeId") Long noticeId){
+        return ResponseEntity.ok(noticeService.findOne(noticeId));
+    }
+
+
+}

--- a/src/main/java/com/kuit/chatdiary/domain/Notice.java
+++ b/src/main/java/com/kuit/chatdiary/domain/Notice.java
@@ -1,0 +1,30 @@
+package com.kuit.chatdiary.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Entity(name = "notice")
+@Getter
+public class Notice {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long noticeId;
+
+    private String title;
+
+    private String content;
+
+    @CreatedDate
+    @Column(name = "create_at")
+    private LocalDateTime createAt;
+
+    @LastModifiedDate
+    @Column(name = "update_at")
+    private LocalDateTime updateAt;
+
+}

--- a/src/main/java/com/kuit/chatdiary/domain/Notice.java
+++ b/src/main/java/com/kuit/chatdiary/domain/Notice.java
@@ -2,22 +2,29 @@ package com.kuit.chatdiary.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
+import java.sql.Date;
 import java.time.LocalDateTime;
 
 @Entity(name = "notice")
 @Getter
+@NoArgsConstructor
 public class Notice {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "user_id")
+    @Column(name = "notice_id")
     private Long noticeId;
 
     private String title;
 
     private String content;
+
+    @CreatedDate
+    @Column(name = "notice_date")
+    private Date noticeDate;
 
     @CreatedDate
     @Column(name = "create_at")
@@ -27,4 +34,8 @@ public class Notice {
     @Column(name = "update_at")
     private LocalDateTime updateAt;
 
+    public Notice(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/kuit/chatdiary/dto/notice/NoticeListResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/notice/NoticeListResponseDTO.java
@@ -1,0 +1,18 @@
+package com.kuit.chatdiary.dto.notice;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NoticeListResponseDTO {
+    private Long id;
+    private String title;
+
+    /** 지금은 쿼리로 날려서 수작업으로 날짜 입력하지만 나중에 작성 매서드 만들면 .now 등으로 서버 날짜 쓰기*/
+    private Date noticeDate;
+
+}

--- a/src/main/java/com/kuit/chatdiary/dto/notice/NoticeResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/notice/NoticeResponseDTO.java
@@ -16,6 +16,8 @@ public class NoticeResponseDTO {
     private String title;
     private String content;
 
+
+    /** 지금은 쿼리로 날려서 수작업으로 날짜 입력하지만 나중에 작성 매서드 만들면 .now 등으로 서버 날짜 쓰기*/
     private Date noticeDate;
 
 }

--- a/src/main/java/com/kuit/chatdiary/dto/notice/NoticeResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/notice/NoticeResponseDTO.java
@@ -1,0 +1,20 @@
+package com.kuit.chatdiary.dto.notice;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NoticeResponseDTO {
+    private Long id;
+
+    private String title;
+    private String content;
+
+    private LocalDateTime createAt;
+    private LocalDateTime updateAt;
+}

--- a/src/main/java/com/kuit/chatdiary/dto/notice/NoticeResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/notice/NoticeResponseDTO.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.Date;
 
 @Getter
 @NoArgsConstructor
@@ -15,6 +16,6 @@ public class NoticeResponseDTO {
     private String title;
     private String content;
 
-    private LocalDateTime createAt;
-    private LocalDateTime updateAt;
+    private Date noticeDate;
+
 }

--- a/src/main/java/com/kuit/chatdiary/repository/notice/NoticeRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/notice/NoticeRepository.java
@@ -1,0 +1,27 @@
+package com.kuit.chatdiary.repository.notice;
+
+import com.kuit.chatdiary.domain.Notice;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class NoticeRepository {
+    private final EntityManager em;
+
+    public NoticeRepository(EntityManager em) {
+        this.em = em;
+    }
+
+    public List<Notice> findAll() {
+        return em.createQuery("select n from notice n", Notice.class)
+                .getResultList();
+    }
+
+    public Notice findOne(Long id) {
+        return em.find(Notice.class, id);
+    }
+
+
+}

--- a/src/main/java/com/kuit/chatdiary/service/notice/NoticeService.java
+++ b/src/main/java/com/kuit/chatdiary/service/notice/NoticeService.java
@@ -1,0 +1,44 @@
+package com.kuit.chatdiary.service.notice;
+
+import com.kuit.chatdiary.domain.Notice;
+import com.kuit.chatdiary.dto.notice.NoticeResponseDTO;
+import com.kuit.chatdiary.repository.notice.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    public List<NoticeResponseDTO> findNotices() {
+        List<Notice> notices = noticeRepository.findAll();
+        return notices.stream()
+                .map(notice -> new NoticeResponseDTO(
+                        notice.getNoticeId(),
+                        notice.getTitle(),
+                        notice.getContent(),
+                        notice.getNoticeDate()))
+                .collect(Collectors.toList());
+    }
+
+    public NoticeResponseDTO findOne(Long noticeId) {
+        Notice notice = noticeRepository.findOne(noticeId);
+        if (notice == null) {
+            return null;
+        }
+        return new NoticeResponseDTO(
+                notice.getNoticeId(),
+                notice.getTitle(),
+                notice.getContent(),
+                notice.getNoticeDate()
+        );
+    }
+
+}

--- a/src/main/java/com/kuit/chatdiary/service/notice/NoticeService.java
+++ b/src/main/java/com/kuit/chatdiary/service/notice/NoticeService.java
@@ -1,6 +1,7 @@
 package com.kuit.chatdiary.service.notice;
 
 import com.kuit.chatdiary.domain.Notice;
+import com.kuit.chatdiary.dto.notice.NoticeListResponseDTO;
 import com.kuit.chatdiary.dto.notice.NoticeResponseDTO;
 import com.kuit.chatdiary.repository.notice.NoticeRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,13 +18,16 @@ public class NoticeService {
 
     private final NoticeRepository noticeRepository;
 
-    public List<NoticeResponseDTO> findNotices() {
+    /**
+     *
+     * */
+
+    public List<NoticeListResponseDTO> findNotices() {
         List<Notice> notices = noticeRepository.findAll();
         return notices.stream()
-                .map(notice -> new NoticeResponseDTO(
+                .map(notice -> new NoticeListResponseDTO(
                         notice.getNoticeId(),
                         notice.getTitle(),
-                        notice.getContent(),
                         notice.getNoticeDate()))
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
구체적으로 논의되고 필수는 아니라 우선 구성해 보았습니다.

## 요약 (Summary)
- [x] 공지사항 리스트 api작성
- [x] 공지사항 상세 api작성

## 변경 사항 (Changes)
- 공지사항 리스트 조회 API를 구현하였습니다. 해당 API는 모든 공지사항을 리스트 형태로 반환합니다.
- 공지사항 상세 조회 API를 구현하였습니다. 해당 API는 공지사항의 ID를 기반으로 해당 공지사항의 상세 정보를 반환합니다.
## 리뷰 요구사항
- [x]  공지사항 데이터 접근 로직이 효율적으로 작성되었는지 확인해 주세요.
- [x] 적절하게 응답이 오는지 확인해주세요

## 확인 방법 

### 요청 주소 예시

#### 공지사항 리스트
```
http://localhost:8080/notice/list
```

#### 공지사항 상세
```
http://localhost:8080/notice/detail?noticeId=1
```

### 쿼리 예시

```
INSERT INTO notice (title, content, notice_date,create_at, update_at) VALUES
('챗 다이어리 가입이벤트', 'PM이 쏜다! 신규 가입자중 10명을 추첩해서 맥북 m3를쏩니다','2024-02-01',NOW(), NOW()),
('챗 다이어리 치치를 잡아라', '치치를 잡아라!', '2024-02-02',NOW(), NOW()),
('챗 다이어리 신규 캐릭 공지', '치치 다다 루루에 이어서 곧 새로운 캐릭터가 공개됩니다. 이 캐릭터는 학습 상담도 해준데요!','2024-02-15', NOW(), NOW());

```

### 포스트맨

#### 리스트
<img width="868" alt="스크린샷 2024-02-12 오후 7 23 44" src="https://github.com/Chat-Diary/BE/assets/137624597/e205d05c-d479-49ce-8307-e9bbe89c48d4">

#### 상세
<img width="868" alt="스크린샷 2024-02-11 오후 3 49 26" src="https://github.com/Chat-Diary/BE/assets/137624597/bb020e10-31bc-4ff7-ae8b-a83ee0a5dbd3">


