### PR TITLE
Fix: CHAT-294-일기-스트릭-API-수정

### DIFF
--- a/src/main/java/com/kuit/chatdiary/repository/diary/DiaryStreakRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/diary/DiaryStreakRepository.java
@@ -24,10 +24,10 @@ public class DiaryStreakRepository {
                 .setParameter("userId",userId)
                 .getResultList();
 
-        /** 오늘 날짜 기준으로 조회하기위한 조건문
-         *  연속 기록있어도 조회기준 날짜 즉 오늘 작성 일기 없다면 연속작성 기록 없는거로
+        /**
+         * 조회 기준 날짜 하루전으로 일기 스트릭 인정해줌
          * */
-        if (diaries.isEmpty() || !diaries.get(0).getDiaryDate().toLocalDate().equals(today)) {
+        if (diaries.isEmpty() || !diaries.get(0).getDiaryDate().toLocalDate().equals(today.minusDays(1))) {
             return 0L;
         }
 

--- a/src/main/java/com/kuit/chatdiary/repository/diary/DiaryStreakRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/diary/DiaryStreakRepository.java
@@ -28,7 +28,11 @@ public class DiaryStreakRepository {
          * 조회 기준 날짜 하루전으로 일기 스트릭 인정해줌
          * */
         if (diaries.isEmpty() || !diaries.get(0).getDiaryDate().toLocalDate().equals(today.minusDays(1))) {
-            return 0L;
+            if(diaries.get(0).getDiaryDate().toLocalDate().equals(today)){
+
+            }else{
+                return 0L;
+            }
         }
 
         long streakCount = 1;


### PR DESCRIPTION
오늘 기준으로하면 사용자의 상식적인 스트릭과 논리적 충돌있어서 하루전으로 기준 수정

## 요약 (Summary)
- [x] streakDate매서드의 조건문에서 today에서 하루 전으로 수정

## 변경 사항 (Changes)
- minusDays 매서드 사용했습니다. 나머지는 거의 동일합니다.
- 조건문이 조금 수정되었습니다. 어플의 사용자입장의 스트릭을 반영했습니다. (오늘 날짜 일기 없으면 어제 기준 스트릭, 오늘 일기 작성하면 기존 스트릭 +1 , 오늘 아무것도 안쓰면 스트릭 깨짐)

## 리뷰 요구사항
- [ ] 오늘날짜에 일기가 없어도 어제 기준의 스트릭이 보여지는지 봐주세요
- [ ] 오늘 날짜 추가되면 스트릭이 변경되는지 확인 부탁드립니다

## 확인 방법 (선택)

### 예시 쿼리

### 예시 주소
```
http://localhost:8080/diary/streak?memberId=1
```

```
INSERT INTO member (email, password, create_at, update_at, status)
VALUES ("user1@gmail.com", "test123", "2024-01-01 13:47:36", "2024-01-01 13:47:36", "ACTIVE");

INSERT INTO tag (category, tag_name)
VALUES ("감정", "기쁨"), ("감정", "슬픔"), ("감정", "화남"), ("감정", "피곤함"), ("감정", "설렘"), ("감정", "당황"), ("감정", "무서움"),
       ("인물", "친구"), ("인물", "가족"), ("인물", "동료"), ("인물", "애인"), ("인물", "지인"),
       ("행동", "식사"), ("행동", "공부"), ("행동", "여행"), ("행동", "술"), ("행동", "영화"),
       ("행동", "수다"), ("행동", "게임"), ("행동", "업무"), ("행동", "운동"), ("행동", "휴식"), ("행동", "독서"), ("행동", "쇼핑"),
       ("장소", "식당"), ("장소", "학교"), ("장소", "회사"), ("장소", "집"), ("장소", "버스"), ("장소", "카페"), ("장소", "병원"),
       ("장소", "헬스장"), ("장소", "은행"), ("장소", "공항");


INSERT INTO diary (user_id, diary_date, title, content, create_at, update_at, status)
VALUES (1,"20240102","title1", "content1", "2024-01-02 23:59:59", "2024-01-02 23:59:59", "ACTIVE"), 
	   (1,"20240103","title2", "content2", "2024-01-03 23:59:59", "2024-01-03 23:59:59", "ACTIVE"),
       (1,"20240128","title3", "content3", "2024-01-28 23:59:59", "2024-01-28 23:59:59", "ACTIVE"), 
       (1,"20240201","title4", "content4", "2024-02-01 23:59:59", "2024-02-01 23:59:59", "ACTIVE"), 
       (1,"20240202","title5", "content5", "2024-02-02 23:59:59", "2024-02-02 23:59:59", "ACTIVE"), 
       (1,"20240203","title6", "content6", "2024-02-03 23:59:59", "2024-02-03 23:59:59", "ACTIVE"), 
       (1,"20240204","title7", "content7", "2024-02-04 23:59:59", "2024-02-04 23:59:59", "ACTIVE"), 
       (1,"20240205","title8", "content8", "2024-02-05 23:59:59", "2024-02-05 23:59:59", "ACTIVE"), 
       (1,"20240206","title9", "content9", "2024-02-06 23:59:59", "2024-02-06 23:59:59", "ACTIVE"), 
       (1,"20240207","title10", "content10", "2024-02-07 23:59:59", "2024-02-07 23:59:59", "ACTIVE"), 
       (1,"20240208","title11", "content11", "2024-02-08 23:59:59", "2024-02-08 23:59:59", "ACTIVE"), 
       (1,"20240209","title12", "content12", "2024-02-09 23:59:59", "2024-02-09 23:59:59", "ACTIVE"), 
       (1,"20240210","title13", "content13", "2024-02-10 23:59:59", "2024-02-10 23:59:59", "ACTIVE"), 
       (1,"20240211","title14", "content14", "2024-02-11 23:59:59", "2024-02-11 23:59:59", "ACTIVE"), 
       (1,"20240212","title15", "content15", "2024-02-12 23:59:59", "2024-02-12 23:59:59", "ACTIVE"),
       (1,"20240213","title15", "content15", "2024-02-13 23:59:59", "2024-02-13 23:59:59", "ACTIVE");
```

#### 하루 추가용 쿼리 ( 다양한 상황 테스트)
```
INSERT INTO diary (user_id, diary_date, title, content, create_at, update_at, status)
VALUES (1,"20240214","title1", "content1", "2024-02-14 23:59:59", "2024-02-14 23:59:59", "ACTIVE"); 

```

### 포스트맨 
<img width="868" alt="스크린샷 2024-02-14 오후 5 51 28" src="https://github.com/Chat-Diary/BE/assets/137624597/83d269ce-b4ab-4977-8a1a-473f688a825f">

