### PR TITLE
Feat: CHAT-297-BE-카카오-로그인-인가코드는 프론트->백

### DIFF
--- a/src/main/java/com/kuit/chatdiary/controller/Login/LogInController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/Login/LogInController.java
@@ -5,12 +5,10 @@ import com.kuit.chatdiary.service.LogInService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.servlet.ModelAndView;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
-import org.springframework.web.servlet.view.RedirectView;
 
 import java.util.Map;
 
@@ -23,8 +21,10 @@ public class LogInController {
     public LogInService logInService;
 
 
-    @GetMapping("/kakao/callback")
-    public ModelAndView login(@RequestParam("code") String code, RedirectAttributes redirectAttributes) throws Exception {
+    //@GetMapping("/kakao/callback")
+    //public ModelAndView login(@RequestParam("code") String code, RedirectAttributes redirectAttributes) throws Exception {
+    @GetMapping("/kakao/login")
+    public ResponseEntity<KakaoLoginResponseDTO> login(@RequestParam(value = "code") String code) throws Exception {
         //1. 클라이언트에서 로그인 코드를 보내줌 (서버에서 할일 X)
         System.out.println("code: "+code);
 
@@ -51,17 +51,12 @@ public class LogInController {
         //가입된 사용자 -> 바로 로그인
         if(isMember){
             log.info("가입된 사용자입니다.");
-            redirectAttributes.addFlashAttribute("message", "로그인 성공!");
         }else{//미가입 사용자 -> 회원가입&로그인
             log.info("미가입 사용자입니다.");
             logInService.saveMember(nickname);
-            redirectAttributes.addFlashAttribute("message", "회원가입 및 로그인 성공!");
         }
         KakaoLoginResponseDTO kakaoLoginResponseDTO = new KakaoLoginResponseDTO(jwt);
-        ModelAndView modelAndView = new ModelAndView(new RedirectView("https://chatdiaryapp.com", true));
-        modelAndView.addObject("kakaoLoginResponseDTO", kakaoLoginResponseDTO);
-        return modelAndView;
-
+        return ResponseEntity.ok().body(kakaoLoginResponseDTO);
     }
 
 }

--- a/src/main/java/com/kuit/chatdiary/controller/Login/LogInController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/Login/LogInController.java
@@ -8,6 +8,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.servlet.view.RedirectView;
 
 import java.util.Map;
 
@@ -21,7 +24,7 @@ public class LogInController {
 
 
     @GetMapping("/kakao/callback")
-    public KakaoLoginResponseDTO login(@RequestParam("code") String code) throws Exception {
+    public ModelAndView login(@RequestParam("code") String code, RedirectAttributes redirectAttributes) throws Exception {
         //1. 클라이언트에서 로그인 코드를 보내줌 (서버에서 할일 X)
         System.out.println("code: "+code);
 
@@ -48,14 +51,16 @@ public class LogInController {
         //가입된 사용자 -> 바로 로그인
         if(isMember){
             log.info("가입된 사용자입니다.");
-            return new KakaoLoginResponseDTO(jwt);
+            redirectAttributes.addFlashAttribute("message", "로그인 성공!");
         }else{//미가입 사용자 -> 회원가입&로그인
             log.info("미가입 사용자입니다.");
             logInService.saveMember(nickname);
-
-            return new KakaoLoginResponseDTO(jwt);
+            redirectAttributes.addFlashAttribute("message", "회원가입 및 로그인 성공!");
         }
-
+        KakaoLoginResponseDTO kakaoLoginResponseDTO = new KakaoLoginResponseDTO(jwt);
+        ModelAndView modelAndView = new ModelAndView(new RedirectView("https://chatdiaryapp.com", true));
+        modelAndView.addObject("kakaoLoginResponseDTO", kakaoLoginResponseDTO);
+        return modelAndView;
 
     }
 

--- a/src/main/java/com/kuit/chatdiary/controller/Login/LogInController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/Login/LogInController.java
@@ -20,9 +20,6 @@ public class LogInController {
     @Autowired
     public LogInService logInService;
 
-
-    //@GetMapping("/kakao/callback")
-    //public ModelAndView login(@RequestParam("code") String code, RedirectAttributes redirectAttributes) throws Exception {
     @GetMapping("/kakao/login")
     public ResponseEntity<KakaoLoginResponseDTO> login(@RequestParam(value = "code") String code) throws Exception {
         //1. 클라이언트에서 로그인 코드를 보내줌 (서버에서 할일 X)

--- a/src/main/java/com/kuit/chatdiary/service/LogInService.java
+++ b/src/main/java/com/kuit/chatdiary/service/LogInService.java
@@ -153,6 +153,7 @@ public class LogInService {
         member.setNickname(nickname);
         member.setEmail(defaultEmail);
         member.setPassword(defaultPassword);
+        member.setStatus("ACTIVE");
 
         memberRepository.save(member);
 


### PR DESCRIPTION
[로그인 방식 변경]
기존: redirect_url을 서버에서 처리
변경: 인가코드 받는거는 프론트에서하고, 서버는 request로 인가코드받고 response로 jwt 넘겨주기만함

## 요약 (Summary)
<!-- 작업한 부분에 대한 간단한 요약을 작성하세요. -->
- [x] 인가코드 받는 주체 변경

## 변경 사항 (Changes)
<!-- 기존과 비교했을 때 해당 PR에서 변경된 내용을 작성하세요. -->
<!-- 어떤 부분을 왜 수정했는지 구체적으로 기술하세요. -->
- 수정 이유: 카카오 로그인을 완료했을때의 url이 없어서 whitelabel error page 가 뜨는 오류 발생
- 수정 사항: 로그인 완료후에 홈 화면으로 가도록 redirectView 추가
 + 추가로 회원가입시 status = ACTIVE로 하였습니다.

-----
[수정]
위 변경사항은 무시하셔도됩니다.
- 수정이유: 인가코드를 서버에서 처리하여 로직이 복잡함 & 포스트맨으로 테스트 불가
- 수정사항: request=인가코드, response=jwt 로 간단하게 수정
-

## 리뷰 요구사항
<!-- 해당 PR에서 중점적으로 혹은 꼭 리뷰가 필요한 사항들을 작성하세요. --> 
<!-- 체크리스트, 특별한 주의 사항 등 자유 형식으로 기술하세요. -->
- [ ] 인가코드를 param으로 넣었을때 jwt가 잘 반환이 되는지 확인
- [ ] 회원가입시 db에 status가 ACTIVE로 들어가는지 확인

## 확인 방법 (선택)
<!-- UI 구현 화면의 스크린샷, 기능 작동 스크린샷 등 작업 결과를 한 눈에 볼 수 있는 자료를 첨부하세요. -->

1. kauth.kakao.com/oauth/authorize?client_id={REST_API}&redirect_uri={REDIRECT_URL}&response_type=code  
 - 크롬으로 들어가셔야합니다! (시크릿창 추천)
 - REST_API는 카카오 디벨로퍼나 Confluence에서 확인할 수 있습니다.
 - REDIRECT_URL은 http://localhost:3000  으로 사용해주세요!
  (원래 8080 사용했었는데 redirect uri는 프론트에서 접근 가능한 주소로 사용해야된다고 합니다..!)
 
2. 이런 창이 뜨면 챗다 계정 입력 후 로그인
![image](https://github.com/Chat-Diary/BE/assets/81453127/58c5764a-2715-4889-80f5-9c2664cf404d)

3. url에 code=%%%  이 부분 복사
<img width="876" alt="image" src="https://github.com/Chat-Diary/BE/assets/81453127/8f0c9e0f-bd1d-4e82-9c11-d95065f3b6a8">

4. 복사한 code 넣고 postman으로 확인 
 http://localhost:8080/kakao/login
<img width="965" alt="image" src="https://github.com/Chat-Diary/BE/assets/81453127/48d3a987-c5e2-4afc-ae68-f9d64fdb23bb">

5. + db member 테이블에 챗다이어리 계정이 저장되었는지 확인