### PR TITLE
Feat: CHAT-225-카카오로그인-userId도반환

### DIFF
--- a/src/main/java/com/kuit/chatdiary/controller/Login/LogInController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/Login/LogInController.java
@@ -31,28 +31,29 @@ public class LogInController {
 
         //3. 사용자 정보 받기
         Map<String, Object> userInfo = logInService.getUserInfo(accessToken);
+        System.out.println("userinfo : "+userInfo);
         String nickname = (String)userInfo.get("nickname");
+        String email = (String) userInfo.get("email");
 
         System.out.println("nickname = " + nickname);
+        System.out.println("email = " + email);
         System.out.println("accessToken = " + accessToken);
 
-        if(nickname == null){
-            throw new Exception("인증되지 않은 사용자입니다");
-        }
-
-        String jwt = logInService.generateJwt(nickname, 3600000);
+        String jwt = logInService.generateJwt(email, 3600000);
         System.out.println("jwt: "+jwt);
 
-        Boolean isMember = logInService.isMember(nickname);
+        Boolean isMember = logInService.isMember(email);
 
         //가입된 사용자 -> 바로 로그인
         if(isMember){
-            log.info("가입된 사용자입니다.");
+            log.info("이미 가입된 사용자입니다.");
         }else{//미가입 사용자 -> 회원가입&로그인
             log.info("미가입 사용자입니다.");
-            logInService.saveMember(nickname);
+            logInService.saveMember(nickname, email);
         }
-        KakaoLoginResponseDTO kakaoLoginResponseDTO = new KakaoLoginResponseDTO(jwt);
+
+        Long userId = logInService.getUserId(email);
+        KakaoLoginResponseDTO kakaoLoginResponseDTO = new KakaoLoginResponseDTO(jwt, userId, nickname);
         return ResponseEntity.ok().body(kakaoLoginResponseDTO);
     }
 

--- a/src/main/java/com/kuit/chatdiary/domain/Member.java
+++ b/src/main/java/com/kuit/chatdiary/domain/Member.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -42,4 +43,7 @@ public class Member {
     @ColumnDefault("'ACTIVE'")
     private String status;
 
+
 }
+
+

--- a/src/main/java/com/kuit/chatdiary/dto/login/KakaoLoginResponseDTO.java
+++ b/src/main/java/com/kuit/chatdiary/dto/login/KakaoLoginResponseDTO.java
@@ -11,4 +11,8 @@ import lombok.Setter;
 @AllArgsConstructor
 public class KakaoLoginResponseDTO {
     private String jwt;
+
+    private Long userId;
+
+    private String nickname;
 }

--- a/src/main/java/com/kuit/chatdiary/repository/MemberRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/MemberRepository.java
@@ -3,6 +3,8 @@ package com.kuit.chatdiary.repository;
 import com.kuit.chatdiary.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Member findByNickname(String nickname);
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/kuit/chatdiary/service/LogInService.java
+++ b/src/main/java/com/kuit/chatdiary/service/LogInService.java
@@ -22,6 +22,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -110,10 +111,20 @@ public class LogInService {
             String result = responseSb.toString();
             JsonParser parser = new JsonParser();
             JsonElement element = parser.parse(result);
+//
+//            JsonObject properties = element.getAsJsonObject().get("properties").getAsJsonObject();
+//            String nickname = properties.getAsJsonObject().get("nickname").getAsString();
 
             JsonObject properties = element.getAsJsonObject().get("properties").getAsJsonObject();
+            JsonObject kakaoAccount = element.getAsJsonObject().get("kakao_account").getAsJsonObject();
+
             String nickname = properties.getAsJsonObject().get("nickname").getAsString();
+            String email = kakaoAccount.getAsJsonObject().get("email").getAsString();
+
+
             userInfo.put("nickname", nickname);
+            userInfo.put("email", email);
+
 
             br.close();
 
@@ -136,22 +147,21 @@ public class LogInService {
                 .compact();
     }
 
-    public Boolean isMember(String nickname) {
-        Member member = memberRepository.findByNickname(nickname);
-        if(member==null){
-            return false;
+    public Boolean isMember(String email) {
+        Optional<Member> member = memberRepository.findByEmail(email);
+        if(member.isPresent()){
+            return true;
         }
-        return true;
+        return false;
     }
 
-    public void saveMember(String nickname) {
-        //이메일, 패스워드는 막넣음
-        String defaultEmail = nickname+"@"+nickname;
+    public void saveMember(String nickname, String email) {
+        //패스워드는 막넣음
         String defaultPassword = nickname+"123";
 
         Member member = new Member();
         member.setNickname(nickname);
-        member.setEmail(defaultEmail);
+        member.setEmail(email);
         member.setPassword(defaultPassword);
         member.setStatus("ACTIVE");
 
@@ -163,5 +173,11 @@ public class LogInService {
             log.info("가입 실패!");
         }
 
+    }
+
+    public Long getUserId(String email){
+        Long userId = memberRepository.findByEmail(email).get().getUserId();
+       // System.out.println("getUserId에서 UserId: "+member.getUserId());
+        return userId;
     }
 }


### PR DESCRIPTION
userId, nickname 함께 반환

## 요약 (Summary)
<!-- 작업한 부분에 대한 간단한 요약을 작성하세요. -->
- [x] 반환값에 userId, nickname 함께 반환

## 변경 사항 (Changes)
<!-- 기존과 비교했을 때 해당 PR에서 변경된 내용을 작성하세요. -->
<!-- 어떤 부분을 왜 수정했는지 구체적으로 기술하세요. -->
1. 
- 기존: jwt만 반환
- 변경: jwt, userId, nickname 모두 반환

2.
- 기존: nickname으로 본인 확인
- 변경: email로 본인 확인

## 리뷰 요구사항
<!-- 해당 PR에서 중점적으로 혹은 꼭 리뷰가 필요한 사항들을 작성하세요. --> 
<!-- 체크리스트, 특별한 주의 사항 등 자유 형식으로 기술하세요. -->
- [ ] jwt, userid, nickname 가 반환되는지 확인
- [ ] email 중복 안되는지 확인

## 확인 방법 (선택)
<!-- UI 구현 화면의 스크린샷, 기능 작동 스크린샷 등 작업 결과를 한 눈에 볼 수 있는 자료를 첨부하세요. -->
1. 로그인
2. 인가코드 복사 -> 포스트맨에 붙여넣기


http://localhost:8080/kakao/login?code=
<img width="709" alt="image" src="https://github.com/Chat-Diary/BE/assets/81453127/4814c12f-3583-47e7-840e-9cbff9a0014a">
