### PR TITLE
Fix: 채팅 조회시 userId 적용

### DIFF
--- a/src/main/java/com/kuit/chatdiary/controller/ChatController.java
+++ b/src/main/java/com/kuit/chatdiary/controller/ChatController.java
@@ -20,11 +20,11 @@ public class ChatController {
     private ChatService chatService;
 
     @GetMapping("/get")
-    public ResponseEntity<List<ChatGetResponseDTO>> getChats(@RequestParam Long chatId) {
-        List<ChatGetResponseDTO> chats = chatService.getChats(chatId);
+    public ResponseEntity<List<ChatGetResponseDTO>> getChats(@RequestParam Long userId, @RequestParam Long chatId) {
+        List<ChatGetResponseDTO> chats = chatService.getChats(userId, chatId);
         if (chats == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Collections.emptyList());
         }
-        return ResponseEntity.ok(chatService.getChats(chatId));
+        return ResponseEntity.ok(chatService.getChats(userId, chatId));
     }
 }

--- a/src/main/java/com/kuit/chatdiary/repository/ChatRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/ChatRepository.java
@@ -2,12 +2,15 @@ package com.kuit.chatdiary.repository;
 
 import com.kuit.chatdiary.domain.Chat;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ChatRepository extends JpaRepository<Chat, Long> {
 
     List<Chat> findTop10ByMember_UserIdOrderByChatIdDesc(Long userId);
-    List<Chat> findTop10ByChatIdGreaterThan(Long lastChatId);
+    @Query("SELECT c FROM chat c WHERE c.member.userId = :userId AND c.chatId > :lastChatId ORDER BY c.chatId DESC")
+    List<Chat> findTop10ByUserIdAndChatIdGreaterThanOrderByChatIdDesc(@Param("userId") Long userId, @Param("lastChatId") Long lastChatId);
     List<Chat> findTopByMember_UserIdOrderByChatIdDesc(Long userId);
 }

--- a/src/main/java/com/kuit/chatdiary/repository/diary/DiaryStreakRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/diary/DiaryStreakRepository.java
@@ -27,10 +27,11 @@ public class DiaryStreakRepository {
         /**
          * 조회 기준 날짜 하루전으로 일기 스트릭 인정해줌
          * */
-        if (diaries.isEmpty() || !diaries.get(0).getDiaryDate().toLocalDate().equals(today.minusDays(1))) {
-            if(diaries.get(0).getDiaryDate().toLocalDate().equals(today)){
-
-            }else{
+        if (diaries.isEmpty()) {
+            return 0L;
+        }
+        if(!diaries.get(0).getDiaryDate().toLocalDate().equals(today.minusDays(1))) {
+            if(!diaries.get(0).getDiaryDate().toLocalDate().equals(today)) {
                 return 0L;
             }
         }

--- a/src/main/java/com/kuit/chatdiary/service/ChatService.java
+++ b/src/main/java/com/kuit/chatdiary/service/ChatService.java
@@ -70,8 +70,8 @@ public class ChatService {
         return "";
     }
 
-    public List<ChatGetResponseDTO> getChats(Long chatId) {
-        List<Chat> chats = chatRepository.findTop10ByChatIdGreaterThan(chatId);
+    public List<ChatGetResponseDTO> getChats(Long userId, Long lastChatId) {
+        List<Chat> chats = chatRepository.findTop10ByUserIdAndChatIdGreaterThanOrderByChatIdDesc(userId, lastChatId);
         if (chats.isEmpty()) {
             return null;
         }


### PR DESCRIPTION
user별 채팅 가져오기 위함

## 요약 (Summary)
<!-- 작업한 부분에 대한 간단한 요약을 작성하세요. -->
- [x] 채팅 조회시 userId별로 조회

## 변경 사항 (Changes)
<!-- 기존과 비교했을 때 해당 PR에서 변경된 내용을 작성하세요. -->
<!-- 어떤 부분을 왜 수정했는지 구체적으로 기술하세요. -->
- 기존: userId를 받지않아 다른 사용자의 채팅도 조회 가능
- 변경: userId를 받아 해당 사용자의 채팅만 조회 가능

## 리뷰 요구사항
<!-- 해당 PR에서 중점적으로 혹은 꼭 리뷰가 필요한 사항들을 작성하세요. --> 
<!-- 체크리스트, 특별한 주의 사항 등 자유 형식으로 기술하세요. -->
- [ ] 주어진 사용자의 채팅만 조회 가능한지


## 확인 방법 (선택)
<!-- UI 구현 화면의 스크린샷, 기능 작동 스크린샷 등 작업 결과를 한 눈에 볼 수 있는 자료를 첨부하세요. -->
http://localhost:8080/chat/get?userId=2&chatId=2
<img width="914" alt="image" src="https://github.com/Chat-Diary/BE/assets/81453127/5f53b346-23b7-4650-bfc2-0b7382dca72e">
