### PR TITLE
Fix: CHAT-314-채팅-조회-역순-수정

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "develop" ]
   pull_request:
-    branches: [ ]
+    branches: [ "develop" ]
 
 permissions:
   contents: read

--- a/src/main/java/com/kuit/chatdiary/repository/ChatRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/ChatRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 public interface ChatRepository extends JpaRepository<Chat, Long> {
 
     List<Chat> findTop10ByMember_UserIdOrderByChatIdDesc(Long userId);
-    @Query("SELECT c FROM chat c WHERE c.member.userId = :userId AND :lastChatId-10 < c.chatId AND c.chatId < :lastChatId ORDER BY c.chatId ASC")
+    @Query("SELECT c FROM chat c WHERE c.member.userId = :userId AND :lastChatId-10 < c.chatId AND c.chatId <= :lastChatId ORDER BY c.chatId ASC")
     List<Chat> findTop10ByUserIdAndChatIdLessThanOrderByChatIdDesc(@Param("userId") Long userId, @Param("lastChatId") Long lastChatId);
     List<Chat> findTopByMember_UserIdOrderByChatIdDesc(Long userId);
 }

--- a/src/main/java/com/kuit/chatdiary/repository/ChatRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/ChatRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 public interface ChatRepository extends JpaRepository<Chat, Long> {
 
     List<Chat> findTop10ByMember_UserIdOrderByChatIdDesc(Long userId);
-    @Query("SELECT c FROM chat c WHERE c.member.userId = :userId AND c.chatId < :lastChatId ORDER BY c.chatId ASC")
+    @Query("SELECT c FROM chat c WHERE c.member.userId = :userId AND :lastChatId-10 < c.chatId AND c.chatId < :lastChatId ORDER BY c.chatId ASC")
     List<Chat> findTop10ByUserIdAndChatIdLessThanOrderByChatIdDesc(@Param("userId") Long userId, @Param("lastChatId") Long lastChatId);
     List<Chat> findTopByMember_UserIdOrderByChatIdDesc(Long userId);
 }

--- a/src/main/java/com/kuit/chatdiary/repository/ChatRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/ChatRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 public interface ChatRepository extends JpaRepository<Chat, Long> {
 
     List<Chat> findTop10ByMember_UserIdOrderByChatIdDesc(Long userId);
-    @Query("SELECT c FROM chat c WHERE c.member.userId = :userId AND c.chatId > :lastChatId ORDER BY c.chatId DESC")
-    List<Chat> findTop10ByUserIdAndChatIdGreaterThanOrderByChatIdDesc(@Param("userId") Long userId, @Param("lastChatId") Long lastChatId);
+    @Query("SELECT c FROM chat c WHERE c.member.userId = :userId AND c.chatId < :lastChatId ORDER BY c.chatId ASC")
+    List<Chat> findTop10ByUserIdAndChatIdLessThanOrderByChatIdDesc(@Param("userId") Long userId, @Param("lastChatId") Long lastChatId);
     List<Chat> findTopByMember_UserIdOrderByChatIdDesc(Long userId);
 }

--- a/src/main/java/com/kuit/chatdiary/service/ChatService.java
+++ b/src/main/java/com/kuit/chatdiary/service/ChatService.java
@@ -71,7 +71,7 @@ public class ChatService {
     }
 
     public List<ChatGetResponseDTO> getChats(Long userId, Long lastChatId) {
-        List<Chat> chats = chatRepository.findTop10ByUserIdAndChatIdGreaterThanOrderByChatIdDesc(userId, lastChatId);
+        List<Chat> chats = chatRepository.findTop10ByUserIdAndChatIdLessThanOrderByChatIdDesc(userId, lastChatId);
         if (chats.isEmpty()) {
             return null;
         }


### PR DESCRIPTION
## 요약 (Summary)
<!-- 작업한 부분에 대한 간단한 요약을 작성하세요. -->
채팅조회 API의 쿼리를 의도대로 다시 설정했습니다

## 변경 사항 (Changes)
<!-- 기존과 비교했을 때 해당 PR에서 변경된 내용을 작성하세요. -->
<!-- 어떤 부분을 왜 수정했는지 구체적으로 기술하세요. -->
- 채팅 조회 시, 인자로 넘긴 ChatID보다 낮은 Chat을 구함
- 채팅 조회 시, 결과로 나오는 Chat 리스트를 ChatID의 오름차순으로 넘김

## 리뷰 요구사항
<!-- 해당 PR에서 중점적으로 혹은 꼭 리뷰가 필요한 사항들을 작성하세요. --> 
<!-- 체크리스트, 특별한 주의 사항 등 자유 형식으로 기술하세요. -->

## 확인 방법 (선택)
<!-- UI 구현 화면의 스크린샷, 기능 작동 스크린샷 등 작업 결과를 한 눈에 볼 수 있는 자료를 첨부하세요. -->
