### PR TITLE
Fix: 채팅 조회 정렬 방향 변경 및 최대 10개로 수정

### DIFF
--- a/src/main/java/com/kuit/chatdiary/repository/ChatRepository.java
+++ b/src/main/java/com/kuit/chatdiary/repository/ChatRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 public interface ChatRepository extends JpaRepository<Chat, Long> {
 
     List<Chat> findTop10ByMember_UserIdOrderByChatIdDesc(Long userId);
-    @Query("SELECT c FROM chat c WHERE c.member.userId = :userId AND c.chatId > :lastChatId ORDER BY c.chatId DESC")
+    @Query("SELECT c FROM chat c WHERE c.member.userId = :userId AND c.chatId > :lastChatId ORDER BY c.chatId ASC")
     List<Chat> findTop10ByUserIdAndChatIdGreaterThanOrderByChatIdDesc(@Param("userId") Long userId, @Param("lastChatId") Long lastChatId);
     List<Chat> findTopByMember_UserIdOrderByChatIdDesc(Long userId);
 }

--- a/src/main/java/com/kuit/chatdiary/service/ChatService.java
+++ b/src/main/java/com/kuit/chatdiary/service/ChatService.java
@@ -72,6 +72,7 @@ public class ChatService {
 
     public List<ChatGetResponseDTO> getChats(Long userId, Long lastChatId) {
         List<Chat> chats = chatRepository.findTop10ByUserIdAndChatIdGreaterThanOrderByChatIdDesc(userId, lastChatId);
+        chats = chats.stream().limit(10).collect(Collectors.toList());
         if (chats.isEmpty()) {
             return null;
         }


### PR DESCRIPTION
## 요약 (Summary)
<!-- 작업한 부분에 대한 간단한 요약을 작성하세요. -->
채팅조회에 userId 추가한 이후 채팅 순서가 거꾸로 뒤집혀 나오던 이슈 수정

## 변경 사항 (Changes)
<!-- 기존과 비교했을 때 해당 PR에서 변경된 내용을 작성하세요. -->
<!-- 어떤 부분을 왜 수정했는지 구체적으로 기술하세요. -->
- 채팅 정렬 순서를 뒤집음
- 쿼리 결과를 limit를 이용해 10개로 잘라줌

## 리뷰 요구사항
<!-- 해당 PR에서 중점적으로 혹은 꼭 리뷰가 필요한 사항들을 작성하세요. --> 
<!-- 체크리스트, 특별한 주의 사항 등 자유 형식으로 기술하세요. -->

## 확인 방법 (선택)
<!-- UI 구현 화면의 스크린샷, 기능 작동 스크린샷 등 작업 결과를 한 눈에 볼 수 있는 자료를 첨부하세요. -->
현재 배포 완료한 뒤 테스트 해봤습니다
